### PR TITLE
Vcst-819

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,16 +47,26 @@ jobs:
         CONTAINER_REGISTRY: virtopaasregistrymain.azurecr.io
         IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/virtostart/platform
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
+
+    - name: Rename docker image
+      run: | 
+        docker images
+        docker tag $IMAGE_REPOSITORY:$TAG $GH_CONTAINER_REPOSITORY:$TAG
+      env:
+        IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/virtostart/platform
+        TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
+        GH_CONTAINER_REPOSITORY: 'virtostart/platform'
     
     - name: Publish Docker Image to GitHub
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
       with:
-          image: 'virtostart'
+          image: 'virtostart/platform'
           tag: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
           docker_user: ${{ secrets.DOCKER_USERNAME }}
           docker_token: ${{ secrets.DOCKER_TOKEN }}
           docker_hub: 'true'
           update_latest: 'true'
+          release_branch: virtostart
 
     - name: Update app
       if: ${{ github.ref == 'refs/heads/virtostart' }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -57,14 +57,14 @@ jobs:
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
         GH_CONTAINER_REPOSITORY: 'ghcr.io/virtocommerce/virtostart'
     
-    - name: Login to Docker Hub
+    - name: Login to GH Registry
       uses: docker/login-action@v3
       with:
         registry: 'ghcr.io'
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Publish Docker Image to GitHub
+    - name: Publish Docker Image to GH Registry
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
       with:
           image: 'ghcr.io/virtocommerce/virtostart'
@@ -73,10 +73,9 @@ jobs:
           docker_token: ${{ secrets.GITHUB_TOKEN }}
           docker_hub: 'false'
           update_latest: 'true'
-          release_branch: VCST-819 #virtostart
+          release_branch: virtostart
 
     - name: Update app
-      if: ${{ github.ref == 'refs/heads/virtostart' }}
       run: |
         vc-build CloudEnvSetParameter -EnvironmentName virtostart-main -CloudToken ${{ secrets.VIRTOSTART_PLATFORM_TOKEN }} -HelmParameters platform.image.tag=$TAG
       env:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -37,7 +37,7 @@ jobs:
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-    - name: Build and Publish Docker Image
+    - name: Build and Publish Docker Image to Virto container registry
       run: |
         vc-build BuildAndPush -DockerUsername $DOCKER_LOGIN -DockerPassword $DOCKER_PASSWORD -DockerfilePath $DOCKERFILE_PATH -DockerImageName $IMAGE_REPOSITORY -DockerImageTag $TAG -DockerRegistryUrl $CONTAINER_REGISTRY
       env:
@@ -57,13 +57,20 @@ jobs:
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
         GH_CONTAINER_REPOSITORY: 'ghcr.io/virtocommerce/virtostart'
     
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: 'ghcr.io'
+        username: $GITHUB_ACTOR
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Publish Docker Image to GitHub
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
       with:
           image: 'ghcr.io/virtocommerce/virtostart'
           tag: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
-          docker_user: ${{ secrets.DOCKER_USERNAME }}
-          docker_token: ${{ secrets.DOCKER_TOKEN }}
+          docker_user: $GITHUB_ACTOR
+          docker_token: ${{ secrets.GITHUB_TOKEN }}
           docker_hub: 'false'
           update_latest: 'true'
           release_branch: virtostart

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -57,12 +57,12 @@ jobs:
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
         GH_CONTAINER_REPOSITORY: 'ghcr.io/virtocommerce/virtostart'
     
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        registry: 'ghcr.io'
-        username: $GITHUB_ACTOR
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Login to Docker Hub
+    #   uses: docker/login-action@v3
+    #   with:
+    #     registry: 'ghcr.io'
+    #     username: $GITHUB_ACTOR
+    #     password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish Docker Image to GitHub
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
@@ -73,7 +73,7 @@ jobs:
           docker_token: ${{ secrets.GITHUB_TOKEN }}
           docker_hub: 'false'
           update_latest: 'true'
-          release_branch: virtostart
+          release_branch: VCST-819 #virtostart
 
     - name: Update app
       if: ${{ github.ref == 'refs/heads/virtostart' }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -57,12 +57,12 @@ jobs:
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
         GH_CONTAINER_REPOSITORY: 'ghcr.io/virtocommerce/virtostart'
     
-    # - name: Login to Docker Hub
-    #   uses: docker/login-action@v3
-    #   with:
-    #     registry: 'ghcr.io'
-    #     username: $GITHUB_ACTOR
-    #     password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: 'ghcr.io'
+        username: $GITHUB_ACTOR
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish Docker Image to GitHub
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -55,16 +55,16 @@ jobs:
       env:
         IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/virtostart/platform
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
-        GH_CONTAINER_REPOSITORY: 'virtostart/platform'
+        GH_CONTAINER_REPOSITORY: 'ghcr.io/virtocommerce/virtostart'
     
     - name: Publish Docker Image to GitHub
       uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
       with:
-          image: 'virtostart/platform'
+          image: 'ghcr.io/virtocommerce/virtostart'
           tag: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
           docker_user: ${{ secrets.DOCKER_USERNAME }}
           docker_token: ${{ secrets.DOCKER_TOKEN }}
-          docker_hub: 'true'
+          docker_hub: 'false'
           update_latest: 'true'
           release_branch: virtostart
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -48,7 +48,18 @@ jobs:
         IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/virtostart/platform
         TAG: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
     
+    - name: Publish Docker Image to GitHub
+      uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
+      with:
+          image: 'virtostart'
+          tag: ${{ env.PLATFORM_VERSION }}-${{ steps.vars.outputs.sha_short }}
+          docker_user: ${{ secrets.DOCKER_USERNAME }}
+          docker_token: ${{ secrets.DOCKER_TOKEN }}
+          docker_hub: 'true'
+          update_latest: 'true'
+
     - name: Update app
+      if: ${{ github.ref == 'refs/heads/virtostart' }}
       run: |
         vc-build CloudEnvSetParameter -EnvironmentName virtostart-main -CloudToken ${{ secrets.VIRTOSTART_PLATFORM_TOKEN }} -HelmParameters platform.image.tag=$TAG
       env:


### PR DESCRIPTION
Add steps to publish a container image to github registry for using with Deploy to Azure button from the [Deploy VC Platform to Azure Cloud](https://docs.virtocommerce.org/platform/developer-guide/Tutorials-and-How-tos/How-tos/deploy-platform-on-azure/?h=deploy+azure) page.