### PR TITLE
VCST-5505-vcst-qa-deployment

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -18,6 +18,9 @@
       },
       {
         "BlobName": "VirtoCommerce.PageBuilderModule_3.1018.0-pr-151-880b.zip"
+      },
+      {
+        "BlobName": "VirtoCommerce.XCart_3.1027.0-pr-135-6df4.zip"
       }      
     ]
     },
@@ -323,10 +326,6 @@
           "Id": "VirtoCommerce.Orders",
           "Version": "3.1012.0"
         },     
-        {
-          "Id": "VirtoCommerce.XCart",
-          "Version": "3.1026.0"
-        },
         {
           "Id": "VirtoCommerce.Search",
           "Version": "3.1006.0"


### PR DESCRIPTION
Deploy the **VCST-5505** fix (vc-module-x-cart PR #135) to **vcst-qa** for QA verification.

- `VirtoCommerce.XCart`: `3.1026.0` (GithubReleases) → `VirtoCommerce.XCart_3.1027.0-pr-135-6df4.zip` (AzureBlob prerelease)

Minimal change: XCart moved to the AzureBlob prerelease source; no other module touched.
Ref: https://virtocommerce.atlassian.net/browse/VCST-5505 · fix PR https://github.com/VirtoCommerce/vc-module-x-cart/pull/135

**Temporary QA repin — revert after VCST-5505 is verified.**