### PR TITLE
Fix vcptcore-stable boot crash: bump VirtoCommerce.Cart 3.1000.1 → 3.1000.2

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -55,7 +55,7 @@
         },
         {
           "Id": "VirtoCommerce.Cart",
-          "Version": "3.1000.1"
+          "Version": "3.1000.2"
         },
         {
           "Id": "VirtoCommerce.Catalog",


### PR DESCRIPTION
## Problem
`vcptcore-stable` crashes on startup — the XCart module fails to initialize and takes the host down:

```
Failed to initialize module VirtoCommerce.XCart
FileNotFoundException: Could not load 'VirtoCommerce.CartModule.Core, Version=3.1000.2.0'
→ Unable to resolve 'VirtoCommerce.XCart.Core.Services.ICartAggregateRepository'
  while activating 'VirtoCommerce.XOrder.Data.Commands.CreateOrderFromCartCommandHandler'
→ Unhandled exception … HostBuilder.Build() → Program.Main
```

## Root cause — module version mismatch
| Component | Version |
|---|---|
| `VirtoCommerce.XCart` (deployed) | 3.1000.6 |
| `VirtoCommerce.Cart` (deployed) | **3.1000.1** |
| `VirtoCommerce.Cart` required by XCart 3.1000.6 | **>= 3.1000.2** (`vc-module-x-cart@3.1000.6` `module.manifest`) |

XCart 3.1000.6 binds to `CartModule.Core` assembly `3.1000.2.0`, which the deployed Cart 3.1000.1 doesn't ship → XCart init aborts → `ICartAggregateRepository` is never registered → XOrder's handler fails DI validation → platform crashes.

## Fix
Bump `VirtoCommerce.Cart` `3.1000.1` → `3.1000.2` (a real released tag) in `backend/packages.json`. One-line, scoped to the Cart entry only.

## Verification after deploy
Platform boots; XCart loads; `/api/carts` responds; then CRX-GQL-101 (xCart cache-invalidation, VCST-5505) can run on stable.

**⚠ DO NOT MERGE until reviewed — merging triggers the Cloud platform deployment to vcptcore-stable.**