### PR TITLE
VCST-5519: deploy vc-frontend#2394 theme → vcptcore-qa

### DIFF
--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.54.0-pr-2392-d4b9-d4b9fa49.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.54.0-pr-2394-cfab-cfabd10b.zip"
 }


### PR DESCRIPTION
Pin the vcptcore-qa storefront theme to the CI prerelease build from **vc-frontend#2394** (VCST-5519 — Update dependencies (major versions), *Ready for test*).

**Change (`theme/artifact.json`):**
- `vc-theme-b2b-vue-2.54.0-pr-2392-d4b9-d4b9fa49.zip` → `vc-theme-b2b-vue-2.54.0-pr-2394-cfab-cfabd10b.zip`

Storefront-only change (dependency major-version upgrades incl. `@unhead/vue` v3); no module/platform artifacts.

⚠️ **DO NOT MERGE until reviewed.** A human merges to deploy. Revert the pin after verification.
Generated via `/qa-deploy-pr VCST-5519 --env=vcptcore`.