### PR TITLE
VCST-5557: Notification template editor UX overhaul- #202

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -6,21 +6,27 @@
   "PlatformAssetUrl": "",
   "Sources": [
     {
-    "Name": "AzureBlob",
-    "Container": "packages",
-    "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-    "Modules": []
+      "Name": "AzureBlob",
+      "Container": "packages",
+      "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
+      "Modules": [
+        {
+          "Id": "VirtoCommerce.Notifications",
+          "Version": "3.1013.0-pr-202-0b9c",
+          "BlobName": "VirtoCommerce.Notifications_3.1013.0-pr-202-0b9c.zip"
+        }
+      ]
     },
     {
       "Name": "GithubReleases",
       "ModuleSources": [
         "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
       ],
-      "Modules": [  
-       {
+      "Modules": [
+        {
           "Id": "VirtoCommerce.Loyalty",
           "Version": "3.1004.0"
-       },
+        },
         {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"
@@ -352,10 +358,6 @@
         {
           "Id": "VirtoCommerce.BackgroundJobs",
           "Version": "3.1050.0"
-        },
-        {
-          "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1012.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `VirtoCommerce.Notifications`: 3.1012.0 (GithubReleases) → 3.1013.0-pr-202-0b9c (AzureBlob) (PR VirtoCommerce/vc-module-notification#202)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5557

> Manifest shape was unexpected — this fell back to a full reserialize; JSON is semantically identical, review with **"Hide whitespace changes"** enabled.

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.