### PR TITLE
VCST-5534: [Agentic Fix] [Price Lists] PUT /api/products/{productId}/prices silently orphans a Price row when the nested Price obj…

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -35,9 +35,9 @@
           "Id": "VirtoCommerce.SeqLog",
           "BlobName": "VirtoCommerce.SeqLog_3.1000.0-pr-2-9e9c.zip"
         },
-          {
+        {
           "BlobName": "VirtoCommerce.Pricing_3.1005.0-pr-236-8706.zip"
-          }
+        }
       ]
     },
     {

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -34,7 +34,10 @@
         {
           "Id": "VirtoCommerce.SeqLog",
           "BlobName": "VirtoCommerce.SeqLog_3.1000.0-pr-2-9e9c.zip"
-        }
+        },
+          {
+          "BlobName": "VirtoCommerce.Pricing_3.1005.0-pr-236-8706.zip"
+          }
       ]
     },
     {
@@ -338,10 +341,6 @@
         {
           "Id": "VirtoCommerce.XCatalog",
           "Version": "3.1014.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Tax",


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcptcore** (`vcptcore-qa`) for QA verification.

- `VirtoCommerce.Pricing`: 3.1004.0 (GithubReleases) → 3.1005.0-pr-236-8706 (AzureBlob) (PR VirtoCommerce/vc-module-pricing#236)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5534

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.