### PR TITLE
VCST-5532: [Security] [Support] Restrict admin back-office sign-in independently of API permissions ("API-only user")

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1051.0",
+  "PlatformVersion": "3.1053.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1051.0",
+  "PlatformImageTag": "3.1053.0-pr-3092-2588-vcst-5532-2588d613",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcptcore** (`vcptcore-qa`) for QA verification.

- `platform`: 3.1051.0 → 3.1053.0 → tag 3.1053.0-pr-3092-2588-vcst-5532-2588d613 (PR VirtoCommerce/vc-platform#3092)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5532

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.