### PR TITLE
VCST-5554: GET /api/order/dashboardStatistics fails 500 — InvalidCastException (String→Boolean)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -2,7 +2,7 @@
   "ManifestVersion": "2.0",
   "PlatformVersion": "3.1053.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1053.0-pr-3093-e27a-vcst-5618-e27ac905",
+  "PlatformImageTag": "3.1053.0-pr-3089-c16b-vcst-5554-c16b5029",
   "PlatformAssetUrl": "",
   "Sources": [
     {


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `platform`: 3.1053.0 → tag 3.1053.0-pr-3093-e27a-vcst-5618-e27ac905 → 3.1053.0 → tag 3.1053.0-pr-3089-c16b-vcst-5554-c16b5029 (PR VirtoCommerce/vc-platform#3089)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5554

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.