### PR TITLE
VCST-5367: deploy SalesRep 3.1001.0-pr-6-4f32 to vcst-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -11,6 +11,9 @@
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
       "Modules": [
         {
+          "BlobName": "VirtoCommerce.SalesRep_3.1001.0-pr-6-4f32.zip"
+        },
+        {
           "BlobName": "VirtoCommerce.Customer_3.1021.0-pr-312-3aa7.zip"
         },
         {
@@ -322,10 +325,6 @@
         {
           "Id": "VirtoCommerce.Catalog",
           "Version": "3.1039.0"
-        },
-        {
-          "Id": "VirtoCommerce.SalesRep",
-          "Version": "3.1000.0"
         },
         {
           "Id": "VirtoCommerce.Shipping",


### PR DESCRIPTION
Pins **VirtoCommerce.SalesRep 3.1001.0-pr-6-4f32** (PR VirtoCommerce/vc-module-sales-rep#6 — *VCST-5367: Configurable layout*) on `vcst-qa`.

**Why:** the saved-layout regression cases (suite 091 `SR-CP-036…050`, suite 093 `SR-HD-019…046` — 42 cases) cannot run on vcst-qa today. Live schema introspection returns 15 `salesRep*` Query fields and `salesRepLayout` is **not** among them; the platform reports `VirtoCommerce.SalesRep 3.1000.0`, below the `3.1001.0-pr-6` that ships the saved-layout API.

**Change:** `VirtoCommerce.SalesRep` moves from `GithubReleases` (3.1000.0) to an `AzureBlob` prerelease pin (`VirtoCommerce.SalesRep_3.1001.0-pr-6-4f32.zip`). Minimal text surgery — `PlatformVersion`, `PlatformImageTag` and every other module are untouched.

⚠ **Prerelease pin — revert after verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)