### PR TITLE
VCST-5637: Deduplicate the product search within a request in x-catalog, behind an overridable seam

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1055.0",
+  "PlatformVersion": "3.1057.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1055.0",
+  "PlatformImageTag": "3.1057.0-pr-3095-3abb-vcst-5637-json-hash-extensions-3abbc5bb",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -21,7 +21,10 @@
         },
         {
           "BlobName": "VirtoCommerce.Loyalty_3.1005.0-pr-15-838b.zip"
-        }     
+        },
+        {
+          "BlobName": "VirtoCommerce.XCatalog_3.1016.0-pr-106-3559.zip"
+        }
       ]
     },
     {
@@ -305,10 +308,6 @@
         {
           "Id": "VirtoCommerce.CustomerReviews",
           "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1015.0"
         },
         {
           "Id": "VirtoCommerce.XPickup",


### PR DESCRIPTION
Deploy 2 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `VirtoCommerce.XCatalog`: 3.1015.0 (GithubReleases) → 3.1016.0-pr-106-3559 (AzureBlob) (PR VirtoCommerce/vc-module-x-catalog#106)
- `platform`: 3.1055.0 → 3.1057.0 → tag 3.1057.0-pr-3095-3abb-vcst-5637-json-hash-extensions-3abbc5bb (PR VirtoCommerce/vc-platform#3095)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5637

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.