### PR TITLE
VCST-5486: Code Review [vc-platform]: Fix: User cache corruption on update

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -2,7 +2,7 @@
   "ManifestVersion": "2.0",
   "PlatformVersion": "3.1057.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1057.0-pr-3095-3abb-vcst-5637-json-hash-extensions-3abbc5bb",
+  "PlatformImageTag": "3.1057.0-pr-3077-6478-user-cache-clone-on-read-6478702f",
   "PlatformAssetUrl": "",
   "Sources": [
     {


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `platform`: 3.1057.0 → tag 3.1057.0-pr-3095-3abb-vcst-5637-json-hash-extensions-3abbc5bb → 3.1057.0 → tag 3.1057.0-pr-3077-6478-user-cache-clone-on-read-6478702f (PR VirtoCommerce/vc-platform#3077)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5486

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.