### PR TITLE
VCST-5544: deploy UCP + OpenTelemetry prerelease artifacts to vcst-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -9,7 +9,14 @@
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": []
+      "Modules": [
+        {
+          "BlobName": "VirtoCommerce.UCP_3.1005.0-pr-6-78e2.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.OpenTelemetry_3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources.zip"
+        }
+      ]
     },
     {
       "Name": "GithubReleases",
@@ -28,10 +35,6 @@
         {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"
-        },
-        {
-          "Id": "VirtoCommerce.OpenTelemetry",
-          "Version": "3.1000.0"
         },
         {
           "Id": "VirtoCommerce.Contentful",
@@ -236,10 +239,6 @@
         {
           "Id": "VirtoCommerce.ProductSnapshot",
           "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.UCP",
-          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.BackInStock",


### PR DESCRIPTION
## Purpose

Deploy the **unmerged** artifacts for [VCST-5544](https://virtocommerce.atlassian.net/browse/VCST-5544)
(*Logging in UCP* — end-to-end UCP observability) to `vcst-qa` so QA can execute the ticket's
12-case verification plan against a live stand.

| Artifact | Current | Proposed | Source |
|---|---|---|---|
| `VirtoCommerce.UCP` | 3.1004.0 (GithubReleases) | `3.1005.0-pr-6-78e2` | [vc-module-ucp#6](https://github.com/VirtoCommerce/vc-module-ucp/pull/6) (open) |
| `VirtoCommerce.OpenTelemetry` | 3.1000.0 (GithubReleases) | `3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources` | [vc-module-opentelemetry#2](https://github.com/VirtoCommerce/vc-module-opentelemetry/pull/2) (open, VCST-5641) |

## Why both modules

UCP #6's `module.manifest` declares an optional dependency on the OpenTelemetry
`3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources` alpha (config-driven tracing sources).
Pinning UCP alone would leave OpenTelemetry at 3.1000.0, so UCP's `ActivitySource` instances would
not be registered with the Platform tracer provider and no UCP/XAPI spans would be exported.

## Risk

- Both artifacts come from **open, unmerged** PRs. UCP #6 currently carries a `CHANGES_REQUESTED`
  review; its CI (`ci`, `swagger-validation`, `auto-tests` ×3, SonarCloud) is green.
- UCP #6 declares **breaking changes**: REST XAPI failures now return HTTP 200 with the original
  GraphQL error envelope instead of a synthetic 502, and MCP UCP failures return `tools/call`
  `isError` results instead of JSON-RPC errors. Existing UCP/xAPI consumers on `vcst-qa` will see
  the new status semantics while this pin is in place.
- **Revert the pin after verification** (both modules back to their GithubReleases entries).

## Verification config the stand needs

The ticket's plan additionally requires, on the deployed host:

- `UCP:Observability:InputCaptureMode` = `ErrorsOnly` (default pass), togglable to `Always` / `None`
- `UCP:Observability:EnableApplicationInsightsCompatibilityBridge` = `true`
- `Information` level for the `VirtoCommerce.UCP` log category

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCST-5544]: https://virtocommerce.atlassian.net/browse/VCST-5544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ