### PR TITLE
VCST-5490: deploy 6 artifacts to vcst

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -15,6 +15,24 @@
         },
         {
           "BlobName": "VirtoCommerce.OpenTelemetry_3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Pricing_3.1006.0-pr-237-c5db.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Inventory_3.1005.0-pr-164-5966.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Store_3.1007.0-pr-174-26e4.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Sitemaps_3.1004.0-pr-92-2e95.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Orders_3.1014.0-pr-503-4875.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-903-e5bf.zip"
         }
       ]
     },
@@ -157,10 +175,6 @@
           "Version": "3.1003.0"
         },
         {
-          "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1003.0"
-        },
-        {
           "Id": "VirtoCommerce.CatalogPublishing",
           "Version": "3.1005.0"
         },
@@ -193,10 +207,6 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1004.0"
-        },
-        {
           "Id": "VirtoCommerce.Marketing",
           "Version": "3.1006.0"
         },
@@ -217,16 +227,8 @@
           "Version": "3.1006.0"
         },
         {
-          "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
-        },
-        {
           "Id": "VirtoCommerce.BackupRestore",
           "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
@@ -329,20 +331,12 @@
           "Version": "3.1008.0"
         },
         {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
-        },
-        {
           "Id": "VirtoCommerce.Xapi",
           "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.XFrontend",
           "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
         },
         {
           "Id": "VirtoCommerce.XCart",


### PR DESCRIPTION
Deploy 6 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `VirtoCommerce.Pricing`: 3.1005.0 (GithubReleases) → 3.1006.0-pr-237-c5db (AzureBlob) (PR VirtoCommerce/vc-module-pricing#237)
- `VirtoCommerce.Inventory`: 3.1004.0 (GithubReleases) → 3.1005.0-pr-164-5966 (AzureBlob) (PR VirtoCommerce/vc-module-inventory#164)
- `VirtoCommerce.Store`: 3.1006.0 (GithubReleases) → 3.1007.0-pr-174-26e4 (AzureBlob) (PR VirtoCommerce/vc-module-store#174)
- `VirtoCommerce.Sitemaps`: 3.1003.0 (GithubReleases) → 3.1004.0-pr-92-2e95 (AzureBlob) (PR VirtoCommerce/vc-module-sitemaps#92)
- `VirtoCommerce.Orders`: 3.1013.0 (GithubReleases) → 3.1014.0-pr-503-4875 (AzureBlob) (PR VirtoCommerce/vc-module-order#503)
- `VirtoCommerce.Catalog`: 3.1040.0 (GithubReleases) → 3.1041.0-pr-903-e5bf (AzureBlob) (PR VirtoCommerce/vc-module-catalog#903)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5490

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.