### PR TITLE
VCST-5533: deploy vc-frontend PR #2421 theme prerelease to vcst-qa

### DIFF
--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://github.com/VirtoCommerce/vc-frontend/releases/download/2.55.0/vc-theme-b2b-vue-2.55.0.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-pr-2421-1e94-1e949ce0.zip"
 }


### PR DESCRIPTION
Pins the **vcst-qa** storefront theme to the PR-#2421 prerelease build so QA can verify [VCST-5533](https://virtocommerce.atlassian.net/browse/VCST-5533) (cart coupons sidebar — WCAG 2.2 AA).

| | |
|---|---|
| Ticket | VCST-5533 |
| Source PR | VirtoCommerce/vc-frontend#2421 (head `1e949ce0`) |
| Theme | `vc-theme-b2b-vue-2.55.0` → `vc-theme-b2b-vue-2.55.0-pr-2421-1e94-1e949ce0` |
| Env | vcst-qa |

Temporary QA pin — revert to the released theme after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCST-5533]: https://virtocommerce.atlassian.net/browse/VCST-5533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ