### PR TITLE
VCST-5623: deploy vc-platform PR #3100 prerelease to vcst-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058.0",
+  "PlatformVersion": "3.1059.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1058.0",
+  "PlatformImageTag": "3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0",
   "PlatformAssetUrl": "",
   "Sources": [
     {


### PR DESCRIPTION
Pins the **vc-platform PR #3100** prerelease build on `vcst-qa` so VCST-5623 can be verified on a deployed environment.

| Field | Before | After |
| --- | --- | --- |
| `PlatformVersion` | `3.1058.0` | `3.1059.0` |
| `PlatformImageTag` | `3.1058.0` | `3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0` |

- Fix PR: https://github.com/VirtoCommerce/vc-platform/pull/3100 (open, all checks green)
- Ticket: https://virtocommerce.atlassian.net/browse/VCST-5623

`vcst-qa` currently runs the release build `3.1058.0`, which does not contain the fix — `POST /api/platform/security/login` still answers `500` for `null`/missing credential fields there today.

Temporary QA pin: revert to the release version once PR #3100 is merged and a release build containing it ships.