### PR TITLE
VCST-5544: bump UCP prerelease on vcst-qa to pr-6-6c60 (exception export fix)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -11,7 +11,7 @@
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
       "Modules": [
         {
-          "BlobName": "VirtoCommerce.UCP_3.1005.0-pr-6-78e2.zip"
+          "BlobName": "VirtoCommerce.UCP_3.1005.0-pr-6-6c60.zip"
         },
         {
           "BlobName": "VirtoCommerce.OpenTelemetry_3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources.zip"


### PR DESCRIPTION
## Re-deploy for QA re-test of VCST-5544

Bumps the UCP pin on `vcst-qa` to the current head of [vc-module-ucp#6](https://github.com/VirtoCommerce/vc-module-ucp/pull/6).

| Module | From | To |
| --- | --- | --- |
| VirtoCommerce.UCP | 3.1005.0-pr-6-78e2 | **3.1005.0-pr-6-6c60** |

Build `6c60` is commit [`6c60962`](https://github.com/VirtoCommerce/vc-module-ucp/commit/6c60962) — *fix(VCST-5544): export XAPI resolver exceptions*, which addresses the AC-3 blocker reported in QA verification on 2026-08-13 (the original CLR exception and stack trace were absent from the failing XAPI dependency, and no `exceptions` row was produced for a UCP operation).

Single-line manifest change; no other pin is touched. `VirtoCommerce.OpenTelemetry` stays on the VCST-5641 alpha so the re-test isolates the UCP change.

The pin is temporary and should be reverted once VCST-5544 is signed off.