### PR TITLE
VCST-5490: deploy 6 artifacts to vcptcore

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -38,6 +38,24 @@
         {
           "Id": "VirtoCommerce.SalesRep",
           "BlobName": "VirtoCommerce.SalesRep_3.1004.0-pr-11-8a78.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Pricing_3.1006.0-pr-237-c5db.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Inventory_3.1005.0-pr-164-5966.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Store_3.1007.0-pr-174-26e4.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Sitemaps_3.1004.0-pr-92-2e95.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Orders_3.1014.0-pr-503-ce6d.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-903-e5bf.zip"
         }
       ]
     },
@@ -47,30 +65,6 @@
         "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
       ],
       "Modules": [
-             {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
-        },
-        {
-          "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1003.0"
-        },
         {
           "Id": "VirtoCommerce.UCP",
           "Version": "3.1004.0"


### PR DESCRIPTION
Deploy 6 PR artifact(s) to **vcptcore** (`vcptcore-qa`) for QA verification.

- `VirtoCommerce.Pricing`: 3.1005.0 (GithubReleases) → 3.1006.0-pr-237-c5db (AzureBlob) (PR VirtoCommerce/vc-module-pricing#237)
- `VirtoCommerce.Inventory`: 3.1005.0 (GithubReleases) → 3.1005.0-pr-164-5966 (AzureBlob) (PR VirtoCommerce/vc-module-inventory#164)
- `VirtoCommerce.Store`: 3.1006.0 (GithubReleases) → 3.1007.0-pr-174-26e4 (AzureBlob) (PR VirtoCommerce/vc-module-store#174)
- `VirtoCommerce.Sitemaps`: 3.1003.0 (GithubReleases) → 3.1004.0-pr-92-2e95 (AzureBlob) (PR VirtoCommerce/vc-module-sitemaps#92)
- `VirtoCommerce.Orders`: 3.1013.0 (GithubReleases) → 3.1014.0-pr-503-ce6d (AzureBlob) (PR VirtoCommerce/vc-module-order#503)
- `VirtoCommerce.Catalog`: 3.1040.0 (GithubReleases) → 3.1041.0-pr-903-e5bf (AzureBlob) (PR VirtoCommerce/vc-module-catalog#903)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5490

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.