### PR TITLE
VCST-5387: deploy 3 artifacts to vcst-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -2,7 +2,7 @@
   "ManifestVersion": "2.0",
   "PlatformVersion": "3.1059.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0",
+  "PlatformImageTag": "3.1059.0-pr-3099-da0b-vcst-5387-top-level-catalog-assets-da0b53ea",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -35,10 +35,13 @@
           "BlobName": "VirtoCommerce.SalesRep_3.1004.0-pr-11-8a78.zip"
         },
         {
-          "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-903-e5bf.zip"
+          "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-904-ce58.zip"
         },
         {
           "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-159-86c6.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.BackupRestore_3.1004.0-pr-5-2048.zip"
         }
       ]
     },
@@ -231,10 +234,6 @@
         {
           "Id": "VirtoCommerce.Search",
           "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackupRestore",
-          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",


### PR DESCRIPTION
Deploy 3 PR artifacts to **vcst-qa** for QA verification of VCST-5387.

- `Platform` image tag: `3.1059.0-pr-3100-1f33-vcst-5623` -> `3.1059.0-pr-3099-da0b-vcst-5387-top-level-catalog-assets-da0b53ea` (VirtoCommerce/vc-platform#3099)
- `VirtoCommerce.Catalog`: `3.1041.0-pr-903-e5bf` -> `3.1041.0-pr-904-ce58` (VirtoCommerce/vc-module-catalog#904)
- `VirtoCommerce.BackupRestore`: `3.1003.0` (GithubReleases) -> `3.1004.0-pr-5-2048` (AzureBlob) (VirtoCommerce/vc-module-backup-restore#5)

All three components are required together: the feature splits the binary-sidecar contracts across Platform, BackupRestore and Catalog, so the feature is not testable unless all three builds are installed.

Note: this displaces two other tickets test builds currently pinned on vcst-qa - Catalog `pr-903` (VCST-5490) and Platform `pr-3100` (VCST-5623). Please coordinate with their owners before merging.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5387

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the environment.