### PR TITLE
vcst-qa: raise modules and Platform to release versions

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1059.0",
+  "PlatformVersion": "3.1060.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0",
+  "PlatformImageTag": "3.1060.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -17,25 +17,7 @@
           "BlobName": "VirtoCommerce.OpenTelemetry_3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources.zip"
         },
         {
-          "BlobName": "VirtoCommerce.Pricing_3.1006.0-pr-237-c5db.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Inventory_3.1005.0-pr-164-5966.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Store_3.1007.0-pr-174-26e4.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Sitemaps_3.1004.0-pr-92-2e95.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Orders_3.1014.0-pr-503-ce6d.zip"
-        },
-        {
           "BlobName": "VirtoCommerce.SalesRep_3.1004.0-pr-11-8a78.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-903-e5bf.zip"
         },
         {
           "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-159-86c6.zip"
@@ -186,7 +168,7 @@
         },
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -198,7 +180,7 @@
         },
         {
           "Id": "VirtoCommerce.Subscription",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.GDPR",
@@ -223,7 +205,7 @@
         {
           "Id": "VirtoCommerce.EventBus",
           "Version": "3.1010.0"
-        }, 
+        },
         {
           "Id": "VirtoCommerce.Assets",
           "Version": "3.1006.0"
@@ -278,7 +260,7 @@
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1008.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.XRecommend",
@@ -290,15 +272,15 @@
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Contracts",
           "Version": "3.1004.0"
-        }, 
+        },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.TaskManagement",
@@ -330,7 +312,7 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1016.0"
+          "Version": "3.1019.0"
         },
         {
           "Id": "VirtoCommerce.XFrontend",
@@ -338,23 +320,47 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1029.0"
-        },              
+          "Version": "3.1030.0"
+        },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1016.0"
-        },       
+          "Version": "3.1018.0"
+        },
         {
           "Id": "VirtoCommerce.Customer",
           "Version": "3.1022.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1015.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",
           "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1041.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1014.0"
+        },
+        {
+          "Id": "VirtoCommerce.Pricing",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.Store",
+          "Version": "3.1007.0"
+        },
+        {
+          "Id": "VirtoCommerce.Sitemaps",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.Inventory",
+          "Version": "3.1007.0"
         }
       ]
     }


### PR DESCRIPTION
Raise vcst-qa to release versions, so the environment has a clean release baseline instead of a mix of other tickets' PR builds.

### Platform

`3.1059.0` (image tag `3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0`) → **`3.1060.0`** release.
PR VirtoCommerce/vc-platform#3100 (VCST-5623) merged 2026-08-14; release `3.1060.0` published 2026-08-18 07:28 UTC — so the release already contains it.

### Moved from a PR blob pin to the release (6)

All of these PRs were merged **before** their release was cut, so nothing is lost:

| Module | from | to | evidence |
|---|---|---|---|
| Catalog | `3.1041.0-pr-903-e5bf` | **3.1041.0** | VCST-5490 merged 09:19Z → release published 09:42Z |
| Orders | `3.1014.0-pr-503-ce6d` | **3.1014.0** | merged 09:16Z → release 09:36Z |
| Pricing | `3.1006.0-pr-237-c5db` | **3.1006.0** | merged 09:16Z → release 09:40Z |
| Store | `3.1007.0-pr-174-26e4` | **3.1007.0** | merged 09:21Z → release 09:42Z |
| Sitemaps | `3.1004.0-pr-92-2e95` | **3.1004.0** | merged 09:20Z → release 09:41Z |
| Inventory | `3.1005.0-pr-164-5966` | **3.1007.0** | merged 09:40Z → release 09:43Z (also a 2-patch upgrade) |

Practical effect: the VCST-5490 "use BackgroundJobs" work is now taken from released builds rather than six separate PR blobs.

### Bumped to the current release (9)

Already on GithubReleases, just behind — notably the whole xAPI layer:

| Module | from | to |
|---|---|---|
| Xapi | 3.1016.0 | **3.1019.0** |
| XCatalog | 3.1016.0 | **3.1018.0** |
| XCart | 3.1029.0 | **3.1030.0** |
| XOrder | 3.1008.0 | **3.1009.0** |
| XPickup | 3.1003.0 | **3.1004.0** |
| ProfileExperienceApiModule | 3.1015.0 | **3.1016.0** |
| WhiteLabeling | 3.1003.0 | **3.1004.0** |
| Subscription | 3.1002.0 | **3.1003.0** |
| CatalogCsvImportModule | 3.1002.0 | **3.1003.0** |

### Deliberately NOT touched (4)

Their PRs are still **open**, so the release does not contain the work and moving them would drop somebody's active test build:

| Module | pin kept | ticket | why |
|---|---|---|---|
| UCP | `3.1005.0-pr-6-6c60` | VCST-5544 | release is 3.1004.0 — would be a downgrade |
| SalesRep | `3.1004.0-pr-11-8a78` | VCST-5647 | release is 3.1003.0 — would be a downgrade |
| PageBuilderModule | `3.1022.0-pr-159-86c6` | VCST-4933 | release 3.1022.0 was cut before the PR |
| OpenTelemetry | `3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources` | VCST-5641 | branch alpha, no merged PR |

### Notes

- AzureBlob pins: **10 → 4** (only the four keeps above). GithubReleases entries: **77 → 83**. No module appears in both sources.
- The diff also normalizes **4 lines of pre-existing trailing whitespace** after commas (EventBus, Contracts, XCart, XCatalog). Review with **"Hide whitespace changes"** enabled.
- **Supersedes #6373** (VCST-5387), which pinned Catalog `pr-904` and Platform `pr-3099` on these same lines. That PR should be closed and re-created on top of this baseline when VCST-5387 is ready to test.

**DO NOT MERGE until reviewed.**
