### PR TITLE
VCST-5686: deploy 4 artifacts to vcst-qa (platform + background-jobs + image-tools + search)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,6 +1,6 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1061.0",
+  "PlatformVersion": "3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a",
   "PlatformAssetUrl": "",

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1060.0",
+  "PlatformVersion": "3.1061.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1060.0",
+  "PlatformImageTag": "3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -21,6 +21,15 @@
         },
         {
           "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-159-86c6.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.BackgroundJobs_3.1051.0-pr-3-a18f.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.ImageTools_3.1004.0-pr-125-555c.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Search_3.1007.0-pr-145-491d.zip"
         }
       ]
     },
@@ -143,10 +152,6 @@
           "Version": "3.1002.0"
         },
         {
-          "Id": "VirtoCommerce.ImageTools",
-          "Version": "3.1003.0"
-        },
-        {
           "Id": "VirtoCommerce.LuceneSearch",
           "Version": "3.1004.0"
         },
@@ -211,20 +216,12 @@
           "Version": "3.1006.0"
         },
         {
-          "Id": "VirtoCommerce.Search",
-          "Version": "3.1006.0"
-        },
-        {
           "Id": "VirtoCommerce.BackupRestore",
           "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
           "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.BackgroundJobs",
-          "Version": "3.1050.0"
         },
         {
           "Id": "VirtoCommerce.ProductSnapshot",


### PR DESCRIPTION
## Deploy VCST-5686 artifacts to vcst-qa

Step 2 of the Hangfire → BackgroundJobs migration (on-demand job cancellation). All four PRs are still OPEN — these are CI prerelease artifacts, deployed together so the cancellation paths can be exercised end to end.

| Artifact | From | To | PR |
| --- | --- | --- | --- |
| Platform | 3.1060.0 | **`3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a`** in both `PlatformVersion` and `PlatformImageTag` | [vc-platform#3097](https://github.com/VirtoCommerce/vc-platform/pull/3097) |
| VirtoCommerce.BackgroundJobs | 3.1050.0 | **3.1051.0-pr-3-a18f** | [vc-module-background-jobs#3](https://github.com/VirtoCommerce/vc-module-background-jobs/pull/3) |
| VirtoCommerce.ImageTools | 3.1003.0 | **3.1004.0-pr-125-555c** | [vc-module-image-tools#125](https://github.com/VirtoCommerce/vc-module-image-tools/pull/125) |
| VirtoCommerce.Search | 3.1006.0 | **3.1007.0-pr-145-491d** | [vc-module-search#145](https://github.com/VirtoCommerce/vc-module-search/pull/145) |

The three modules move from the `GithubReleases` source to the `AzureBlob` prerelease source, with their old `GithubReleases` entries removed so no duplicate Id is left behind. Both `PlatformVersion` and `PlatformImageTag` carry the full PR container tag, at the operator’s request. Note that `deploy-backend.yml` only reads `PlatformImageTag` (line 42, via jq) — `PlatformVersion` is metadata here, and holding a pre-release tag makes it non-semver for anything that parses it. 13 manifest lines changed, produced by `scripts/deploy/deploy-pr-artifact.ts` `editPackagesText` so the edit matches what the tool itself would write.

**Note for reviewers:** vc-platform#3097 currently has one failing check, `auto-tests / auto-autotests (postgres)`. Deploying regardless so the cancellation behaviour can be tested on a stand — but that failure is worth a separate look, since the platform build is the foundation for the other three artifacts.

Temporary pin — revert after VCST-5686 sign-off.
