### PR TITLE
VCST-5745: deploy 1 artifact to vcst

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -30,6 +30,9 @@
         },
         {
           "BlobName": "VirtoCommerce.Search_3.1007.0-pr-145-491d.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1004.0-pr-145-d59d.zip"
         }
       ]
     },
@@ -170,10 +173,6 @@
         {
           "Id": "VirtoCommerce.CatalogPublishing",
           "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",


### PR DESCRIPTION
Deploy 1 PR artifact to **vcst** (`vcst-qa`) for QA verification.

- `VirtoCommerce.CatalogCsvImportModule`: 3.1003.0 (GithubReleases) → 3.1004.0-pr-145-d59d (AzureBlob) (PR VirtoCommerce/vc-module-catalog-csv-export-import#145)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5745

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.