### PR TITLE
Update all modules and platform to latest versions (vcptcore-qa1)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1051.0",
+  "PlatformVersion": "3.1060.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1051.0",
+  "PlatformImageTag": "3.1060.0",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -14,26 +14,11 @@
       "Modules": [
         {
           "Id": "VirtoCommerce.AI",
-          "BlobName": "VirtoCommerce.AI_3.1000.0.zip"
+          "BlobName": "VirtoCommerce.AI_3.1001.0.zip"
         },
         {
-          "BlobName": "VirtoCommerce.AIDocumentProcessing_3.901.0-pr-7-05c5.zip"
-        },
-        {
-          "Id": "VirtoCommerce.AlgoliaSearch_3.801.0",
-          "BlobName": "VirtoCommerce.AlgoliaSearch_3.801.0-pr-3-a62c.zip"
-        },
-        {
-          "Id": "VirtoCommerce.PowerBiReports",
-          "BlobName": "VirtoCommerce.PowerBiReports_3.800.0-pr-5-3363.zip"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "BlobName": "VirtoCommerce.Catalog_3.1039.0-pr-901-a16e.zip"
-        },
-        {
-          "Id": "VirtoCommerce.SeqLog",
-          "BlobName": "VirtoCommerce.SeqLog_3.1000.0-pr-2-9e9c.zip"
+          "Id": "VirtoCommerce.AIDocumentProcessing",
+          "BlobName": "VirtoCommerce.AIDocumentProcessing_3.901.0.zip"
         }
       ]
     },
@@ -43,17 +28,17 @@
         "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
       ],
       "Modules": [
-         {
+        {
           "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1004.0"
-       },
+          "Version": "3.1005.0"
+        },
         {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"
         },
         {
           "Id": "VirtoCommerce.XFrontend",
-          "Version": "3.1003.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.OpenTelemetry",
@@ -65,11 +50,11 @@
         },
         {
           "Id": "VirtoCommerce.SystemOperations",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Quote",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.PriceExportImport",
@@ -89,11 +74,11 @@
         },
         {
           "Id": "VirtoCommerce.MarketingExperienceApi",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1002.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.BuilderIO",
@@ -101,11 +86,11 @@
         },
         {
           "Id": "VirtoCommerce.XRecommend",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.OpenIdConnectModule",
@@ -125,7 +110,7 @@
         },
         {
           "Id": "VirtoCommerce.BackInStock",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.OpenSearch",
@@ -137,7 +122,7 @@
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1002.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.EnvironmentsCompare",
@@ -149,7 +134,7 @@
         },
         {
           "Id": "VirtoCommerce.ProductSnapshot",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.Core",
@@ -209,7 +194,7 @@
         },
         {
           "Id": "VirtoCommerce.Payment",
-          "Version": "3.1004.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Content",
@@ -221,15 +206,15 @@
         },
         {
           "Id": "VirtoCommerce.Pages",
-          "Version": "3.1007.0"
+          "Version": "3.1008.0"
         },
         {
           "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.FileExperienceApi",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPublishing",
@@ -237,15 +222,15 @@
         },
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.PushMessages",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -257,7 +242,7 @@
         },
         {
           "Id": "VirtoCommerce.Subscription",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.GDPR",
@@ -265,7 +250,7 @@
         },
         {
           "Id": "VirtoCommerce.XCMS",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Return",
@@ -277,11 +262,11 @@
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",
-          "Version": "3.1004.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1004.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Marketing",
@@ -293,11 +278,11 @@
         },
         {
           "Id": "VirtoCommerce.News",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.TaskManagement",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.EventBus",
@@ -305,11 +290,11 @@
         },
         {
           "Id": "VirtoCommerce.Cart",
-          "Version": "3.1007.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1007.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.Assets",
@@ -321,15 +306,15 @@
         },
         {
           "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.PageBuilderModule",
-          "Version": "3.1017.0"
+          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.UCP",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.BackupRestore",
@@ -337,35 +322,35 @@
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1014.0"
+          "Version": "3.1018.0"
         },
         {
           "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Tax",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1015.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
-        },
-        {
-          "Id": "VirtoCommerce.Shipping",
           "Version": "3.1006.0"
         },
         {
+          "Id": "VirtoCommerce.Tax",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1019.0"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "Version": "3.1014.0"
+        },
+        {
+          "Id": "VirtoCommerce.Shipping",
+          "Version": "3.1007.0"
+        },
+        {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1028.0"
+          "Version": "3.1030.0"
         },
         {
           "Id": "VirtoCommerce.Customer",
-          "Version": "3.1020.0"
+          "Version": "3.1022.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
@@ -377,11 +362,27 @@
         },
         {
           "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1012.0"
+          "Version": "3.1013.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1013.0"
+          "Version": "3.1016.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1041.0"
+        },
+        {
+          "Id": "VirtoCommerce.AlgoliaSearch",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.PowerBiReports",
+          "Version": "3.803.0"
+        },
+        {
+          "Id": "VirtoCommerce.SeqLog",
+          "Version": "3.1001.0"
         }
       ]
     }


### PR DESCRIPTION
Refresh the `vcptcore-qa1` deployment manifest to the latest released Platform and module versions.

## Platform
`3.1051.0` -> **`3.1060.0`** (latest release, 2026-08-18; `ghcr.io/virtocommerce/platform:3.1060.0` verified present).

## Modules — GithubReleases
**39 modules bumped** to the latest stable version in `vc-modules/master/modules_v3.json`:

| Module | From | To |
|---|---|---|
| XCatalog | 3.1014.0 | 3.1018.0 |
| XCart | 3.1028.0 | 3.1030.0 |
| Xapi | 3.1015.0 | 3.1019.0 |
| PageBuilderModule | 3.1017.0 | 3.1021.0 |
| Customer | 3.1020.0 | 3.1022.0 |
| ProfileExperienceApiModule | 3.1013.0 | 3.1016.0 |
| Inventory | 3.1004.0 | 3.1007.0 |
| Cart | 3.1007.0 | 3.1009.0 |
| XOrder | 3.1007.0 | 3.1009.0 |
| Pricing | 3.1004.0 | 3.1006.0 |
| Payment | 3.1004.0 | 3.1006.0 |
| CustomerReviews | 3.1004.0 | 3.1006.0 |
| XFrontend | 3.1003.0 | 3.1006.0 |
| Orders | 3.1013.0 | 3.1014.0 |
| Notifications | 3.1012.0 | 3.1013.0 |
| Pages | 3.1007.0 | 3.1008.0 |
| Store | 3.1006.0 | 3.1007.0 |
| Shipping | 3.1006.0 | 3.1007.0 |
| WhiteLabeling | 3.1002.0 | 3.1004.0 |
| XPickup | 3.1002.0 | 3.1004.0 |
| Loyalty · Tax · News · TaskManagement · PushMessages | +1 patch each | |
| Quote · Skyflow · Subscription · XCMS · UCP · Contracts · Sitemaps · FileExperienceApi · CatalogCsvImportModule · MarketingExperienceApi · ProductSnapshot · SystemOperations · XRecommend · BackInStock | +1 patch each | |

## Modules — AzureBlob prereleases resolved
The AzureBlob section held 6 modules pinned to PR/prerelease builds. Four of them are now available as public GitHub releases and were **moved to `GithubReleases`**:

| Module | Was (blob) | Now (release) |
|---|---|---|
| VirtoCommerce.Catalog | `3.1039.0-pr-901-a16e` | **3.1041.0** |
| VirtoCommerce.AlgoliaSearch | `3.801.0-pr-3-a62c` | **3.1001.0** |
| VirtoCommerce.PowerBiReports | `3.800.0-pr-5-3363` | **3.803.0** |
| VirtoCommerce.SeqLog | `3.1000.0-pr-2-9e9c` | **3.1001.0** |

`Catalog` carried the `feat/VCST-5428` PR build (vc-module-catalog#901, *"Fixed admin console error parentBlade.refresh is not a function"*). That PR was merged to `dev` on 2026-08-04 and release `3.1041.0` shipped on 2026-08-18, so the fix is now covered by the release and the pin is no longer needed.

The remaining two stay on AzureBlob **but were moved onto their release blobs**:

| Module | Was | Now |
|---|---|---|
| VirtoCommerce.AI | `VirtoCommerce.AI_3.1000.0.zip` | `VirtoCommerce.AI_3.1001.0.zip` |
| VirtoCommerce.AIDocumentProcessing | `..._3.901.0-pr-7-05c5.zip` | `..._3.901.0.zip` |

They **cannot** move to `GithubReleases`: `vc-module-ai` and `vc-module-ai-document-processing` are private repositories, so their release assets return 404 to an anonymous download and the deploy would fail at module-install time. The release-version blobs in `vc3prerelease` are public and were verified reachable. This also fixes two latent defects in those entries — `AIDocumentProcessing` had **no `Id` at all**, and `AlgoliaSearch`'s `Id` carried a version suffix (`VirtoCommerce.AlgoliaSearch_3.801.0`).

## Verification
- Dependency graph of the resulting 91-module set resolves — no missing or too-old dependency, no declared incompatibility.
- No module requires a Platform newer than 3.1060.0 (highest requirement: `XCatalog 3.1018.0` -> 3.1057.0).
- All 89 `GithubReleases` package URLs return HTTP 200; both AzureBlob blobs return HTTP 200.
- `XCMS 3.1004.0` / `PageBuilderModule 3.1021.0` assembly coupling holds (XCMS requires PageBuilderModule >= 3.1012.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
