### PR TITLE
VCST-5387: deploy 3 artifacts to vcptcore-qa1 + storefront 2.55.0

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1060.0",
+  "PlatformVersion": "3.1061.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1060.0",
+  "PlatformImageTag": "3.1061.0-pr-3099-829a-vcst-5387-top-level-catalog-assets-829afe69",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -19,6 +19,14 @@
         {
           "Id": "VirtoCommerce.AIDocumentProcessing",
           "BlobName": "VirtoCommerce.AIDocumentProcessing_3.901.0.zip"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "BlobName": "VirtoCommerce.Catalog_3.1042.0-pr-904-2bfa.zip"
+        },
+        {
+          "Id": "VirtoCommerce.BackupRestore",
+          "BlobName": "VirtoCommerce.BackupRestore_3.1004.0-pr-5-2048.zip"
         }
       ]
     },
@@ -317,10 +325,6 @@
           "Version": "3.1004.0"
         },
         {
-          "Id": "VirtoCommerce.BackupRestore",
-          "Version": "3.1003.0"
-        },
-        {
           "Id": "VirtoCommerce.XCatalog",
           "Version": "3.1018.0"
         },
@@ -367,10 +371,6 @@
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
           "Version": "3.1016.0"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1041.0"
         },
         {
           "Id": "VirtoCommerce.AlgoliaSearch",

--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.54.0-alpha.2436.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0.zip"
 }


### PR DESCRIPTION
Deliver **VCST-5387** (stream catalog image/file binaries during backup/restore) to **vcptcore-qa1** for QA verification, and move the storefront off an alpha onto the latest release.

All three backend components are required together — the feature splits its binary-sidecar contracts across Platform, BackupRestore and Catalog, so none of it is observable unless all three builds are installed.

### Backend — VCST-5387 PR builds

| Target | Current | Proposed | PR |
|---|---|---|---|
| Platform | `3.1060.0` | **`3.1061.0`**, image tag `3.1061.0-pr-3099-829a-vcst-5387-top-level-catalog-assets-829afe69` | VirtoCommerce/vc-platform#3099 |
| VirtoCommerce.Catalog | `3.1041.0` (GithubReleases) | **`3.1042.0-pr-904-2bfa`** (AzureBlob) | VirtoCommerce/vc-module-catalog#904 |
| VirtoCommerce.BackupRestore | `3.1003.0` (GithubReleases) | **`3.1004.0-pr-5-2048`** (AzureBlob) | VirtoCommerce/vc-module-backup-restore#5 |

Each pin matches its PR's current head commit: `829afe69`, `2bfacceb`, `20482a6c`.

### Storefront — latest release

| Current | Proposed |
|---|---|
| `vc-theme-b2b-vue-2.54.0-alpha.2436.zip` (alpha prerelease) | **`vc-theme-b2b-vue-2.55.0.zip`** (release 2.55.0, published 2026-08-12) |

`2.55.0` is the newest non-prerelease vc-frontend release. The URL was taken from that release's own asset name rather than string-substituted, and the blob was verified present and non-empty (9 177 690 bytes, Last-Modified 2026-08-12) before this PR was opened.

### Notes

- **Platform moves up, not down.** PR #3099 was rebuilt on 2026-08-19 against base `3.1061.0`, so this is a one-minor upgrade from the `3.1060.0` currently pinned — not the stale `3.1059.0-pr-3099` build from 2026-08-11. The `ghcr.io/virtocommerce/platform` manifest for the tag above was confirmed present (HTTP 200).
- **Nothing is displaced.** vcptcore-qa1 carried only two AzureBlob pins (`VirtoCommerce.AI`, `VirtoCommerce.AIDocumentProcessing`); both are preserved untouched. No other ticket's test build is overwritten.
- `packages.json`: AzureBlob pins 2 → 4, GithubReleases entries 89 → 87. Catalog and BackupRestore change source, so no module appears in both sources. New AzureBlob entries carry `Id` + `BlobName`, matching the existing convention on this branch.
- **vc-platform#3099 is `mergeable_state: unstable`** (its own checks are not green). Acceptable for a test-environment pin, but it should not be read as a release-ready build.

### After deploy

Verification is the 21-case suite `regression/suites/Backend/import-export/096-catalog-backup-binary-sidecars.csv`. Start with **BKRS-001**: the Catalog `module.manifest` declares `platformVersion 3.1059.0-alpha.13363-vcst-5387-top-level-catalog-assets`, so the first check is that the Catalog module actually loads against the deployed Platform and reports no validation errors.

**DO NOT MERGE until reviewed.** Revert these pins after the change is verified.
