### PR TITLE
VCST-5704: deploy 2 artifacts to vcptcore_qa1

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -39,6 +39,9 @@
         {
           "Id": "VirtoCommerce.Skyflow",
           "BlobName": "VirtoCommerce.Skyflow_3.1005.0-pr-25-82f2.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-160-df89.zip"
         }
       ]
     },
@@ -323,10 +326,6 @@
         {
           "Id": "VirtoCommerce.Store",
           "Version": "3.1007.0"
-        },
-        {
-          "Id": "VirtoCommerce.PageBuilderModule",
-          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.UCP",

--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2426-4f40-4f40ffbf.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2441-ab1c-ab1cc71d.zip"
 }


### PR DESCRIPTION
Deploy 2 PR artifact(s) to **vcptcore_qa1** (`vcptcore-qa1`) for QA verification of VCST-5704.

VCST-5704 spans TWO repos and both halves are required — the designer offers page-wide anchors, the theme renders the matching element ids and scrolls to them. Deploying only one half cannot verify that a produced `#anchor` link actually resolves.

- `VirtoCommerce.PageBuilderModule`: 3.1021.0 (GithubReleases) → 3.1022.0-pr-160-df89 (AzureBlob) — PR VirtoCommerce/vc-module-pagebuilder#160
- `theme`: vc-theme-b2b-vue-2.56.0-pr-2426-4f40 → vc-theme-b2b-vue-2.56.0-pr-2441-ab1c — PR VirtoCommerce/vc-frontend#2441

⚠ The theme pin currently on this branch is **pr-2426** (VCST-5450, configurable company roles). This PR replaces it — coordinate if someone is testing VCST-5450 on vcptcore-qa1.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5704

**DO NOT MERGE until reviewed.** Revert both pins after the change is verified on the env.