### PR TITLE
VCST-5745: deploy CatalogCsvImportModule 3.1004.0-pr-145-5581 to vcptcore-qa1

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -42,6 +42,10 @@
         },
         {
           "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-160-df89.zip"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
+          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1004.0-pr-145-5581.zip"
         }
       ]
     },
@@ -238,10 +242,6 @@
         {
           "Id": "VirtoCommerce.CatalogPublishing",
           "Version": "3.1005.0"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.PushMessages",


### PR DESCRIPTION
Deploys the **PR #145** prerelease of `VirtoCommerce.CatalogCsvImportModule` to **vcptcore-qa1** so VCST-5745 can be verified on that environment.

| Artifact | Current | New |
|---|---|---|
| VirtoCommerce.CatalogCsvImportModule | 3.1003.0 (GithubReleases) | **3.1004.0-pr-145-5581** (AzureBlob) |

Source PR: VirtoCommerce/vc-module-catalog-csv-import#145 (head `5581fd1`, Module CI green).
Ticket: https://virtocommerce.atlassian.net/browse/VCST-5745

Test-env pin only — revert after verification.