### PR TITLE
VCST-5752: theme PR #2449 build; move module pins to release versions

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,37 +1,15 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a",
+  "PlatformVersion": "3.1061.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1061.0-pr-3097-dff9-vcst-5686-dff9e74a",
+  "PlatformImageTag": "3.1061.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
       "Name": "AzureBlob",
       "Container": "packages",
       "ServiceUri": "https://vc3prerelease.blob.core.windows.net",
-      "Modules": [
-        {
-          "BlobName": "VirtoCommerce.UCP_3.1005.0-pr-6-6c60.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.OpenTelemetry_3.1001.0-alpha.6-vcst-5641-config-driven-tracing-sources.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-159-86c6.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.BackgroundJobs_3.1051.0-pr-3-a18f.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.ImageTools_3.1004.0-pr-125-555c.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Search_3.1007.0-pr-145-491d.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1004.0-pr-145-d59d.zip"
-        }
-      ]
+      "Modules": []
     },
     {
       "Name": "GithubReleases",
@@ -237,7 +215,7 @@
         },
         {
           "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.MarketingExperienceApi",
@@ -358,6 +336,34 @@
         {
           "Id": "VirtoCommerce.Inventory",
           "Version": "3.1007.0"
+        },
+        {
+          "Id": "VirtoCommerce.UCP",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.OpenTelemetry",
+          "Version": "3.1001.0"
+        },
+        {
+          "Id": "VirtoCommerce.PageBuilderModule",
+          "Version": "3.1021.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackgroundJobs",
+          "Version": "3.1050.0"
+        },
+        {
+          "Id": "VirtoCommerce.ImageTools",
+          "Version": "3.1003.0"
+        },
+        {
+          "Id": "VirtoCommerce.Search",
+          "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
+          "Version": "3.1004.0"
         }
       ]
     }

--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2410-5cd3-5cd3dad3.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2449-63de-63ded416.zip"
 }


### PR DESCRIPTION
## backend/packages.json — prerelease pins → release

| Module | Was | Now |
|---|---|---|
| Platform (+ImageTag) | 3.1061.0-pr-3097-dff9-vcst-5686 | 3.1061.0 |
| UCP | 3.1005.0-pr-6-6c60 | 3.1005.0 |
| OpenTelemetry | 3.1001.0-alpha.6-vcst-5641-… | 3.1001.0 |
| CatalogCsvImportModule | 3.1004.0-pr-145-d59d | 3.1004.0 |
| PageBuilderModule | 3.1022.0-pr-159-86c6 | 3.1021.0 |
| BackgroundJobs | 3.1051.0-pr-3-a18f | 3.1050.0 |
| ImageTools | 3.1004.0-pr-125-555c | 3.1003.0 |
| Search | 3.1007.0-pr-145-491d | 3.1006.0 |
| Skyflow | 3.1004.0 | **3.1005.0** |

The AzureBlob source is kept with an empty `Modules: []`, mirroring `vcptcore-demo`. All 8 target versions were verified in `modules_v3.json`: empty `VersionTag` + a `github.com/.../releases/download/` `PackageUrl` (not an alpha), so no 404 rollback on deploy. After this change the pins match `vcptcore-demo` exactly, except `Loyalty 3.1005.0` which demo does not carry at all.

## theme/artifact.json — VCST-5752

`vc-theme-b2b-vue-2.56.0-pr-2410-5cd3-5cd3dad3.zip` → `vc-theme-b2b-vue-2.56.0-pr-2449-63de-63ded416.zip`

From VirtoCommerce/vc-frontend#2449 (`fix(VCST-5752): settings icon`). Latest build — `63ded416` matches the PR head SHA.

## Note

Merging triggers the Cloud platform deployment Action and rolls back the PR builds currently on the env (VCST-5686 Platform, VCST-5641 OpenTelemetry, pagebuilder PR-159, ImageTools PR-125, Search PR-145, BackgroundJobs PR-3, CatalogCsvImport PR-145) — confirm nobody is still testing those.