### PR TITLE
chore(virtostart): align module + platform versions with vcst-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,6 +1,6 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058.0",
+  "PlatformVersion": "3.1061.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -76,11 +76,11 @@
         },
         {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
+          "Version": "3.1041.0"
         },
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1002.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPersonalization",
@@ -172,7 +172,7 @@
         },
         {
           "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1004.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Loyalty",
@@ -216,7 +216,7 @@
         },
         {
           "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
+          "Version": "3.1014.0"
         },
         {
           "Id": "VirtoCommerce.PageBuilderModule",
@@ -236,7 +236,7 @@
         },
         {
           "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.ProductSnapshot",
@@ -244,7 +244,7 @@
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1015.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.PushMessages",
@@ -276,11 +276,11 @@
         },
         {
           "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.SqlQueries",
@@ -288,11 +288,11 @@
         },
         {
           "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Subscription",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.SystemOperations",
@@ -308,7 +308,7 @@
         },
         {
           "Id": "VirtoCommerce.UCP",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.WebHooks",
@@ -316,19 +316,19 @@
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1016.0"
+          "Version": "3.1019.0"
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1029.0"
+          "Version": "3.1030.0"
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1016.0"
+          "Version": "3.1018.0"
         },
         {
           "Id": "VirtoCommerce.XCMS",
@@ -340,11 +340,11 @@
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1008.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.XRecommend",


### PR DESCRIPTION
Aligns the `virtostart` deploy manifest with the versions currently on `vcst-qa`.

**Platform:** 3.1058.0 → **3.1061.0**

**17 modules bumped** (all forward — no downgrades):

| Module | from | to |
| --- | --- | --- |
| VirtoCommerce.Xapi | 3.1016.0 | 3.1019.0 |
| VirtoCommerce.XCatalog | 3.1016.0 | 3.1018.0 |
| VirtoCommerce.Inventory | 3.1004.0 | 3.1007.0 |
| VirtoCommerce.CatalogCsvImportModule | 3.1002.0 | 3.1004.0 |
| VirtoCommerce.XCart | 3.1029.0 | 3.1030.0 |
| VirtoCommerce.Catalog | 3.1040.0 | 3.1041.0 |
| VirtoCommerce.Orders | 3.1013.0 | 3.1014.0 |
| VirtoCommerce.Pricing | 3.1005.0 | 3.1006.0 |
| VirtoCommerce.ProfileExperienceApiModule | 3.1015.0 | 3.1016.0 |
| VirtoCommerce.Sitemaps | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.Skyflow | 3.1004.0 | 3.1005.0 |
| VirtoCommerce.Store | 3.1006.0 | 3.1007.0 |
| VirtoCommerce.Subscription | 3.1002.0 | 3.1003.0 |
| VirtoCommerce.UCP | 3.1004.0 | 3.1005.0 |
| VirtoCommerce.WhiteLabeling | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.XOrder | 3.1008.0 | 3.1009.0 |
| VirtoCommerce.XPickup | 3.1003.0 | 3.1004.0 |

**Deliberately NOT changed:**

- The 65 modules already at the same version on both environments.
- The 5 modules present only on `vcst-qa` (`SalesRep`, `ElasticSearch`, `Contentful`, `Sanity`, `OpenTelemetry`) — out of scope; they were never on `virtostart`.
- The two `AzureBlob` entries (`AIDocumentProcessing` PR build, `PowerBiReports` alpha) — carry a `BlobName` and no `Id`/`Version`, so they are untouched and verified still present.

**Diff is version-values only.** The edit was applied by targeted replacement, not a JSON round-trip: line count is unchanged (357 → 357), no keys added or removed, and no version changed outside the 17 above (asserted programmatically before committing).

**Worth knowing before merge:** these versions were read from the `vcst-qa` **manifest**, not from the running instance. A manifest can lead what is actually deployed — that exact drift showed up on `vcst-qa` earlier today with the theme. If it matters here, confirm against `/api/platform/modules` on `vcst-qa` before merging.