### PR TITLE
chore(vcst-qa): deploy theme pr-2451 (VCST-5777 icon strokes)

### DIFF
--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2449-63de-63ded416.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2451-8ba8-8ba8bd04.zip"
 }


### PR DESCRIPTION
Points the `vcst-qa` storefront theme at the **pr-2451** prerelease build.

```
- vc-theme-b2b-vue-2.56.0-pr-2449-63de-63ded416.zip
+ vc-theme-b2b-vue-2.56.0-pr-2451-8ba8-8ba8bd04.zip
```

**pr-2451** = vc-frontend#2451 — `fix(VCST-5777): render outline icon strokes without non-scaling-stroke` (1 file, `vc-icon.vue`, +48/−3).

Artifact verified reachable before committing: HTTP 200, 9,207,624 bytes, built 2026-08-25 14:58 UTC.

**VCST-5752 is preserved.** The theme slot holds one build, so this replaces pr-2449 (`fix(VCST-5752): settings icon`) — but the 2451 branch was rebased and carries those changes too. Verified by content on `fix/VCST-5777-thin-icons-chrome`, not by commit graph (a rebase rewrites SHAs, so `git compare` reports the branches as diverged and is the wrong instrument here):

| File | Expected marker | Present |
| --- | --- | --- |
| wishlist-dropdown-menu.vue | `variant="solid"` | yes |
| members-dropdown-menu.vue | `variant="solid"` | yes |
| address-dropdown-menu.vue | `variant="solid"` | yes |
| list-details.vue | `prepend-icon="settings"` | yes |

So this deploy carries **both** icon fixes. VCST-5752 was verified on vcst-qa today (PASS with notes — all four icon surfaces measured against the ≤14px→solid / ≥16px→outline rule); after this deploy that verification still holds, and VCST-5777 becomes testable on top of it.