### PR TITLE
virtostart: theme and storybook 2.55.0 -> 2.56.0

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -177,8 +177,8 @@
   storefront:
     enabled: false
     themes:
-      B2B-store: https://github.com/VirtoCommerce/vc-frontend/releases/download/2.55.0/vc-theme-b2b-vue-2.55.0.zip
-      B2B-loyalty: https://github.com/VirtoCommerce/vc-frontend/releases/download/2.55.0/vc-theme-b2b-vue-2.55.0.zip
+      B2B-store: https://github.com/VirtoCommerce/vc-frontend/releases/download/2.56.0/vc-theme-b2b-vue-2.56.0.zip
+      B2B-loyalty: https://github.com/VirtoCommerce/vc-frontend/releases/download/2.56.0/vc-theme-b2b-vue-2.56.0.zip
     headers:
         Cross-Origin-Embedder-Policy: unsafe-none
         Cross-Origin-Resource-Policy: cross-origin

--- a/storybook/image.json
+++ b/storybook/image.json
@@ -1,4 +1,4 @@
 {
     "Repository": "ghcr.io/virtocommerce/vc-theme-b2b-vue-storybook",
-    "Tag": "2.55.0"
+    "Tag": "2.56.0"
 }


### PR DESCRIPTION
Updates virtostart to vc-frontend [2.56.0](https://github.com/VirtoCommerce/vc-frontend/releases/tag/2.56.0).

| What | File | From | To |
|---|---|---|---|
| Theme `B2B-store` | `infra/environments.yml` | 2.55.0 | 2.56.0 |
| Theme `B2B-loyalty` | `infra/environments.yml` | 2.55.0 | 2.56.0 |
| Storybook image tag | `storybook/image.json` | 2.55.0 | 2.56.0 |

Verified before pushing:
- theme asset `vc-theme-b2b-vue-2.56.0.zip` exists on the release (anonymous download returns 200);
- `ghcr.io/virtocommerce/vc-theme-b2b-vue-storybook:2.56.0` exists in the registry.

`customApps.app1.imageTag` in `infra/environments.yml` is deliberately left untouched — `custom.app1.image.tag` is listed under `protectedParameters`, so the deployed storybook tag comes from `storybook/image.json` via the "Cloud storybook deployment" workflow, not from that field.

Merging this triggers the storefront/storybook deployment on virtostart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)