### PR TITLE
VCST-5450: deploy PR builds to vcptcore-qa (modules + platform + theme)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1061.0",
+  "PlatformVersion": "3.1062.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1061.0",
+  "PlatformImageTag": "3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -41,6 +41,14 @@
         },
         {
           "BlobName": "VirtoCommerce.Catalog_3.1041.0-pr-903-e5bf.zip"
+        },
+        {
+          "Id": "VirtoCommerce.ProfileExperienceApiModule",
+          "BlobName": "VirtoCommerce.ProfileExperienceApiModule_3.1017.0-pr-143-9eae.zip"
+        },
+        {
+          "Id": "VirtoCommerce.Customer",
+          "BlobName": "VirtoCommerce.Customer_3.1023.0-alpha.1009-vcst-5450.zip"
         }
       ]
     },
@@ -349,14 +357,6 @@
         {
           "Id": "VirtoCommerce.XCatalog",
           "Version": "3.1018.0"
-        },
-        {
-          "Id": "VirtoCommerce.Customer",
-          "Version": "3.1022.0"
-        },
-        {
-          "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,6 +1,6 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1062.0",
+  "PlatformVersion": "3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5",
   "ModuleSources": [

--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.57.0-pr-2441-4d56-4d565716.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.57.0-pr-2426-acb5-acb549d6.zip"
 }


### PR DESCRIPTION
Deploys the VCST-5450 PR builds to **vcptcore-qa**.

| Target | Current on `vcptcore-qa` | This PR | Source |
|---|---|---|---|
| `VirtoCommerce.ProfileExperienceApiModule` | 3.1016.0 (release) | `3.1017.0-pr-143-9eae` (blob) | [vc-module-profile-experience-api#143](https://github.com/VirtoCommerce/vc-module-profile-experience-api/pull/143) |
| `VirtoCommerce.Customer` | 3.1022.0 (release) | `3.1023.0-alpha.1009-vcst-5450` (blob) | [vc-module-customer#314](https://github.com/VirtoCommerce/vc-module-customer/pull/314) |
| Platform | 3.1061.0 | `3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5` (both `PlatformVersion` and `PlatformImageTag`) | [vc-platform#3098](https://github.com/VirtoCommerce/vc-platform/pull/3098) |
| Storefront theme | `2.57.0-pr-2441-4d56` | `2.57.0-pr-2426-acb5-acb549d6` | [vc-frontend#2426](https://github.com/VirtoCommerce/vc-frontend/pull/2426) |

Verified before pushing:
- both module blobs and the theme blob return HTTP 200 on `vc3prerelease`;
- `ghcr.io/virtocommerce/platform:3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5` exists (the tag matches PR #3098 head `a2e4afa5`; the PR body carries no image tag, so it was supplied explicitly);
- module count in `packages.json` is unchanged (92), no other pin touched.

⚠ Risk on the platform pin: the same image has been pinned on **vcptcore-qa1** since 2026-08-21 and that environment has been `Degraded / OutOfSync` ever since — it never rolled a healthy pod and still serves the pre-21.08 container. If vcptcore-qa degrades after merge, revert `PlatformVersion`/`PlatformImageTag` to `3.1061.0`; the module and theme pins can stay.

Note: GitHub Actions had a major outage at the time this was prepared (incident 15:09 UTC), so the deployment workflows did not run. Merging this PR produces the push that triggers "Cloud platform deployment" and "Cloud theme deployment".

🤖 Generated with [Claude Code](https://claude.com/claude-code)