### PR TITLE
VCST-5729: Code Review [vc-frontend]: fix(search-bar): show only one category scope indicator while the scope is loading

### DIFF
--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://github.com/VirtoCommerce/vc-frontend/releases/download/2.56.0/vc-theme-b2b-vue-2.56.0.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.57.0-pr-2436-f3bf-f3bffc67.zip"
 }


### PR DESCRIPTION
Deploy 1 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `theme`: vc-theme-b2b-vue-2.56.0.zip → vc-theme-b2b-vue-2.57.0-pr-2436-f3bf-f3bffc67.zip (PR VirtoCommerce/vc-frontend#2436)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5729

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.