### PR TITLE
Align vcptcore-loadtest with virtostart: platform 3.1061.0 + 18 module bumps

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1058.0",
+  "PlatformVersion": "3.1061.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1058.0",
+  "PlatformImageTag": "3.1061.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {
@@ -23,7 +23,7 @@
         },
         {
           "Id": "VirtoCommerce.OpenTelemetry",
-          "Version": "3.1000.0"
+          "Version": "3.1001.0"
         },
         {
           "Id": "VirtoCommerce.Contentful",
@@ -159,7 +159,7 @@
         },
         {
           "Id": "VirtoCommerce.Sitemaps",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.CatalogPublishing",
@@ -167,7 +167,7 @@
         },
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1002.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
@@ -179,7 +179,7 @@
         },
         {
           "Id": "VirtoCommerce.Subscription",
-          "Version": "3.1002.0"
+          "Version": "3.1003.0"
         },
         {
           "Id": "VirtoCommerce.GDPR",
@@ -195,7 +195,7 @@
         },
         {
           "Id": "VirtoCommerce.Inventory",
-          "Version": "3.1004.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Marketing",
@@ -223,7 +223,7 @@
         },
         {
           "Id": "VirtoCommerce.Store",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.BackupRestore",
@@ -231,7 +231,7 @@
         },
         {
           "Id": "VirtoCommerce.Pricing",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Tax",
@@ -239,15 +239,15 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1016.0"
+          "Version": "3.1019.0"
         },
         {
           "Id": "VirtoCommerce.Orders",
-          "Version": "3.1013.0"
+          "Version": "3.1014.0"
         },
         {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1040.0"
+          "Version": "3.1041.0"
         },
         {
           "Id": "VirtoCommerce.Shipping",
@@ -255,7 +255,7 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1029.0"
+          "Version": "3.1030.0"
         },
         {
           "Id": "VirtoCommerce.Customer",
@@ -283,7 +283,7 @@
         },
         {
           "Id": "VirtoCommerce.UCP",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.BackInStock",
@@ -299,7 +299,7 @@
         },
         {
           "Id": "VirtoCommerce.Skyflow",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.MarketingExperienceApi",
@@ -315,7 +315,7 @@
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1008.0"
+          "Version": "3.1009.0"
         },
         {
           "Id": "VirtoCommerce.XRecommend",
@@ -327,11 +327,11 @@
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "Version": "3.1015.0"
+          "Version": "3.1016.0"
         },
         {
           "Id": "VirtoCommerce.WhiteLabeling",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.Contracts",
@@ -343,11 +343,11 @@
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1016.0"
+          "Version": "3.1018.0"
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.TaskManagement",


### PR DESCRIPTION
Brings the **vcptcore-loadtest** environment to parity with **virtostart**, so load-test numbers are measured against the same code as the reference env.

Baseline: live `/api/platform/modules` on both envs (2026-08-31) — the manifests agreed with the live state module-for-module.

### Platform

| | before | after |
|---|---|---|
| `PlatformVersion` | 3.1058.0 | **3.1061.0** |
| `PlatformImageTag` | 3.1058.0 | **3.1061.0** |

`PlatformImageTag` is bumped too — it exists in this manifest (virtostart has no such key), and leaving it would keep the old container despite the version bump. Both tags verified present in `ghcr.io/virtocommerce/platform`.

### Modules aligned to virtostart (17)

| Module | before | after |
|---|---|---|
| VirtoCommerce.Xapi | 3.1016.0 | 3.1019.0 |
| VirtoCommerce.XCatalog | 3.1016.0 | 3.1018.0 |
| VirtoCommerce.XCart | 3.1029.0 | 3.1030.0 |
| VirtoCommerce.XOrder | 3.1008.0 | 3.1009.0 |
| VirtoCommerce.XPickup | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.ProfileExperienceApiModule | 3.1015.0 | 3.1016.0 |
| VirtoCommerce.Catalog | 3.1040.0 | 3.1041.0 |
| VirtoCommerce.CatalogCsvImportModule | 3.1002.0 | 3.1004.0 |
| VirtoCommerce.Inventory | 3.1004.0 | 3.1007.0 |
| VirtoCommerce.Orders | 3.1013.0 | 3.1014.0 |
| VirtoCommerce.Pricing | 3.1005.0 | 3.1006.0 |
| VirtoCommerce.Store | 3.1006.0 | 3.1007.0 |
| VirtoCommerce.Sitemaps | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.Subscription | 3.1002.0 | 3.1003.0 |
| VirtoCommerce.WhiteLabeling | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.Skyflow | 3.1004.0 | 3.1005.0 |
| VirtoCommerce.UCP | 3.1004.0 | 3.1005.0 |

The whole xAPI layer plus Catalog/Inventory were behind — exactly the surface a load test exercises.

### Loadtest-only modules — checked for newer releases

| Module | pinned | latest in `modules_v3.json` | action |
|---|---|---|---|
| VirtoCommerce.OpenTelemetry | 3.1000.0 | 3.1001.0 (release) | **bumped** |
| VirtoCommerce.ElasticSearch | 3.806.0 | 3.807.0 `alpha.292` | kept |
| VirtoCommerce.Contentful | 3.1001.0 | 3.1002.0 `alpha.130` | kept |
| VirtoCommerce.Sanity | 3.1003.0 | 3.1004.0 `alpha.11` | kept |

The three "newer" builds are alpha pre-releases: the feed's `Version` field strips the tag suffix, and their `PackageUrl` is not a GitHub release asset — pinning one under `GithubReleases` 404s and rolls back the whole deploy.

### Why Catalog is 3.1041.0 and not 3.1042.0

`VirtoCommerce.Catalog` **3.1042.0** is a real release, but it requires platform **>= 3.1062.0**. This PR lands on 3.1061.0, so it would not start. 3.1041.0 is what virtostart runs.

### Verification done before commit

- Every target package URL probed anonymously — all `200` (incl. `Catalog_3.1041.0.zip`, which is no longer listed in the feed but resolves by release tag).
- Platform-version floors of the new module versions all satisfied by 3.1061.0 — highest is `XCatalog` at `>= 3.1057.0`.
- Both `ghcr.io/virtocommerce/platform` tags exist.
- Diff is exactly 20 changed lines, JSON re-parsed, no line-ending churn.
- The whole combination is already running on virtostart.

Merging this PR triggers "Cloud platform deployment" on `vcptcore-loadtest` and redeploys the environment.

Not touched: `Loyalty`, `AIDocumentProcessing`, `PowerBiReports` exist on virtostart but not on loadtest — out of scope here, and the latter two are pre-release AzureBlob pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
