### PR TITLE
Align loadtest theme with virtostart: vc-theme-b2b-vue 2.56.0

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -126,7 +126,7 @@
     #   VirtoCommerce__Endpoint__Password: Password1!
     #   VirtoCommerce__Endpoint__UserName: admin
     themes:
-      B2B-store:  https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-alpha.2454.zip
+      B2B-store:  https://github.com/VirtoCommerce/vc-frontend/releases/download/2.56.0/vc-theme-b2b-vue-2.56.0.zip
   customApps:
     app1:
       name: storybook


### PR DESCRIPTION
Makes the **vcptcore-loadtest** storefront theme identical to **virtostart**, completing the parity work started in #6427 (platform + modules).

### Change

`infra/environments.yml` → `themes.B2B-store`:

| | before | after |
|---|---|---|
| source | `vc3prerelease` blob | GitHub release asset |
| version | `2.55.0-alpha.2454` | **`2.56.0`** |

```
- B2B-store:  https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-alpha.2454.zip
+ B2B-store:  https://github.com/VirtoCommerce/vc-frontend/releases/download/2.56.0/vc-theme-b2b-vue-2.56.0.zip
```

The URL is copied verbatim from the `virtostart` branch. Besides matching the reference environment, this moves loadtest off an alpha prerelease onto a stable release — appropriate for an environment whose numbers are supposed to be reproducible.

### Verification

- Asset probed anonymously: `200`.
- `2.56.0` is the newest `vc-frontend` release, and it is what virtostart serves — no newer stable exists to pick instead.
- YAML re-parsed after the edit; diff is a single line.

### Deliberately not changed

- **`B2B-loyalty` theme mapping.** virtostart maps a second store to the same ZIP, but loadtest has neither that store nor the `VirtoCommerce.Loyalty` module, so the entry would point at nothing.
- **`storybook/image.json`** is still pinned to `2.19.0-alpha.1737-vcst-2850-ui-kit-…` (virtostart is on `2.56.0`), and **`storefront/image.json`** to a matching `2.19.0-alpha` storefront container. Both are out of scope for "the theme" and belong in their own change.

Merging triggers "Cloud infra deployment" on `vcptcore-loadtest`.

> Note: the Actions runs for #6427 failed to start — `The job was not started because your account is locked due to a billing issue` — so that manifest is merged but **not deployed**. The same will apply here until Actions billing is unblocked; both workflows support `workflow_dispatch` for a re-run afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
