### PR TITLE
VCST-5801: deploy XCart PR-139 gift-merge fix + Catalog 3.1042.0 to vcptcore-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -26,6 +26,10 @@
         {
           "Id": "VirtoCommerce.Customer",
           "BlobName": "VirtoCommerce.Customer_3.1023.0-alpha.1009-vcst-5450.zip"
+        },
+        {
+          "Id": "VirtoCommerce.XCart",
+          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-139-2f78.zip"
         }
       ]
     },
@@ -328,10 +332,6 @@
           "Version": "3.1006.0"
         },
         {
-          "Id": "VirtoCommerce.XCart",
-          "Version": "3.1030.0"
-        },
-        {
           "Id": "VirtoCommerce.XCatalog",
           "Version": "3.1018.0"
         },
@@ -365,7 +365,7 @@
         },
         {
           "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1041.0"
+          "Version": "3.1042.0"
         },
         {
           "Id": "VirtoCommerce.Orders",


### PR DESCRIPTION
Deploy the VCST-5801 fix + a lagging module bump to **vcptcore-qa** for QA verification.

- `VirtoCommerce.XCart`: 3.1030.0 (GithubReleases) → **3.1031.0-pr-139-2f78** (AzureBlob) — prerelease of the open fix PR VirtoCommerce/vc-module-x-cart#139 "Merge only non-gift items"
- `VirtoCommerce.Catalog`: 3.1041.0 → **3.1042.0** (only module on this env behind its latest stable release)

In-flight pins left untouched on purpose: Platform `3.1063.0-pr-3098-…-vcst-5450`, `VirtoCommerce.Customer` `3.1023.0-alpha.1009-vcst-5450`, `VirtoCommerce.ProfileExperienceApiModule` `3.1017.0-pr-143-58c3`.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5801

Note: the XCart prerelease is built from `dev`, so unmerged `dev` changes ride along with the fix.

**DO NOT MERGE until reviewed.** Revert the XCart pin after the fix is verified (or after PR #139 is released).