### PR TITLE
VCST-5661: deploy 6 artifacts to vcptcore-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -29,7 +29,33 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-139-2f78.zip"
+          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-138-d7b6.zip",
+          "Version": "3.1031.0-pr-138-d7b6"
+        },
+        {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1020.0-pr-83-32fe",
+          "BlobName": "VirtoCommerce.Xapi_3.1020.0-pr-83-32fe.zip"
+        },
+        {
+          "Id": "VirtoCommerce.XCatalog",
+          "Version": "3.1019.0-pr-110-83cf",
+          "BlobName": "VirtoCommerce.XCatalog_3.1019.0-pr-110-83cf.zip"
+        },
+        {
+          "Id": "VirtoCommerce.XOrder",
+          "Version": "3.1010.0-pr-50-242d",
+          "BlobName": "VirtoCommerce.XOrder_3.1010.0-pr-50-242d.zip"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
+          "Version": "3.1005.0-pr-11-32cd",
+          "BlobName": "VirtoCommerce.XPickup_3.1005.0-pr-11-32cd.zip"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
+          "Version": "3.1005.0-pr-146-8990",
+          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1005.0-pr-146-8990.zip"
         }
       ]
     },
@@ -184,10 +210,6 @@
           "Version": "3.1005.0"
         },
         {
-          "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1004.0"
-        },
-        {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
           "Version": "3.1003.0"
         },
@@ -276,10 +298,6 @@
           "Version": "3.1004.0"
         },
         {
-          "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1009.0"
-        },
-        {
           "Id": "VirtoCommerce.XRecommend",
           "Version": "3.1002.0"
         },
@@ -289,10 +307,6 @@
         },
         {
           "Id": "VirtoCommerce.Contracts",
-          "Version": "3.1004.0"
-        },
-        {
-          "Id": "VirtoCommerce.XPickup",
           "Version": "3.1004.0"
         },
         {
@@ -324,16 +338,8 @@
           "Version": "3.1008.0"
         },
         {
-          "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1019.0"
-        },
-        {
           "Id": "VirtoCommerce.XFrontend",
           "Version": "3.1006.0"
-        },
-        {
-          "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1018.0"
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -29,32 +29,26 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-138-d7b6.zip",
-          "Version": "3.1031.0-pr-138-d7b6"
+          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-138-d7b6.zip"
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1020.0-pr-83-32fe",
           "BlobName": "VirtoCommerce.Xapi_3.1020.0-pr-83-32fe.zip"
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1019.0-pr-110-83cf",
           "BlobName": "VirtoCommerce.XCatalog_3.1019.0-pr-110-83cf.zip"
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1010.0-pr-50-242d",
           "BlobName": "VirtoCommerce.XOrder_3.1010.0-pr-50-242d.zip"
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1005.0-pr-11-32cd",
           "BlobName": "VirtoCommerce.XPickup_3.1005.0-pr-11-32cd.zip"
         },
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "Version": "3.1005.0-pr-146-8990",
           "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1005.0-pr-146-8990.zip"
         }
       ]


### PR DESCRIPTION
Deploy the VCST-5661 ("Replacing AutoMapper — Wave 3") prerelease artifacts to **vcptcore-qa** so QA can test the change end-to-end.

Ticket: https://virtocommerce.atlassian.net/browse/VCST-5661 (Ready for test)

## Artifacts

| Module | Current on branch | Pinned to | Source PR |
|---|---|---|---|
| VirtoCommerce.Xapi | 3.1019.0 (GithubReleases) | 3.1020.0-pr-83-32fe | VirtoCommerce/vc-module-x-api#83 |
| VirtoCommerce.XCart | 3.1031.0-pr-139-2f78 (AzureBlob) | 3.1031.0-pr-138-d7b6 | VirtoCommerce/vc-module-x-cart#138 |
| VirtoCommerce.XCatalog | 3.1018.0 (GithubReleases) | 3.1019.0-pr-110-83cf | VirtoCommerce/vc-module-x-catalog#110 |
| VirtoCommerce.XOrder | 3.1009.0 (GithubReleases) | 3.1010.0-pr-50-242d | VirtoCommerce/vc-module-x-order#50 |
| VirtoCommerce.XPickup | 3.1004.0 (GithubReleases) | 3.1005.0-pr-11-32cd | VirtoCommerce/vc-module-x-pickup#11 |
| VirtoCommerce.CatalogCsvImportModule | 3.1004.0 (GithubReleases) | 3.1005.0-pr-146-8990 | VirtoCommerce/vc-module-catalog-csv-export-import#146 |

Platform, theme and every other pin on this branch are untouched (the existing VCST-5450 pins — Customer alpha + Platform 3.1063.0-pr-3098 — stay as they are).

## Heads-up: XCart pin is replaced

`VirtoCommerce.XCart` on this branch is currently pinned to **PR #139 (VCST-5801 "Merge only non-gift items")**. VCST-5661 also changes x-cart, so this PR repoints XCart to **PR #138**. If VCST-5801 is still being tested on vcptcore-qa, coordinate before merging.

## Notes

- All six PRs are **open/unmerged**; these are `vc3prerelease` CI builds, so a re-run of any PR's CI produces a new blob and this pin goes stale.
- A prerelease artifact's `module.manifest` often keeps the base version (the `-pr-…` suffix lives only in the blob name), so a version mismatch in `/api/platform/modules` is advisory — confirm by behaviour.
- The diff is a full reserialize (JSON semantically identical) — review with **Hide whitespace changes** enabled. 5 entries move from `GithubReleases` to `AzureBlob`, XCart is re-pinned in place.
- **Revert the pins after verification.**

Prepared with `/qa-deploy-pr` (`scripts/deploy/deploy-pr-artifact.ts`). Merging this PR triggers the "Cloud platform deployment" action — a human merges.