### PR TITLE
VCST-5661: revert the vcptcore-qa artifact pins (QA verification complete)

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -29,27 +29,7 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-138-d7b6.zip"
-        },
-        {
-          "Id": "VirtoCommerce.Xapi",
-          "BlobName": "VirtoCommerce.Xapi_3.1020.0-pr-83-32fe.zip"
-        },
-        {
-          "Id": "VirtoCommerce.XCatalog",
-          "BlobName": "VirtoCommerce.XCatalog_3.1019.0-pr-110-83cf.zip"
-        },
-        {
-          "Id": "VirtoCommerce.XOrder",
-          "BlobName": "VirtoCommerce.XOrder_3.1010.0-pr-50-242d.zip"
-        },
-        {
-          "Id": "VirtoCommerce.XPickup",
-          "BlobName": "VirtoCommerce.XPickup_3.1005.0-pr-11-32cd.zip"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1005.0-pr-146-8990.zip"
+          "BlobName": "VirtoCommerce.XCart_3.1031.0-pr-139-2f78.zip"
         }
       ]
     },
@@ -204,6 +184,10 @@
           "Version": "3.1005.0"
         },
         {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
+          "Version": "3.1004.0"
+        },
+        {
           "Id": "VirtoCommerce.AuthorizeNetPayment",
           "Version": "3.1003.0"
         },
@@ -292,6 +276,10 @@
           "Version": "3.1004.0"
         },
         {
+          "Id": "VirtoCommerce.XOrder",
+          "Version": "3.1009.0"
+        },
+        {
           "Id": "VirtoCommerce.XRecommend",
           "Version": "3.1002.0"
         },
@@ -301,6 +289,10 @@
         },
         {
           "Id": "VirtoCommerce.Contracts",
+          "Version": "3.1004.0"
+        },
+        {
+          "Id": "VirtoCommerce.XPickup",
           "Version": "3.1004.0"
         },
         {
@@ -332,8 +324,16 @@
           "Version": "3.1008.0"
         },
         {
+          "Id": "VirtoCommerce.Xapi",
+          "Version": "3.1019.0"
+        },
+        {
           "Id": "VirtoCommerce.XFrontend",
           "Version": "3.1006.0"
+        },
+        {
+          "Id": "VirtoCommerce.XCatalog",
+          "Version": "3.1018.0"
         },
         {
           "Id": "VirtoCommerce.CustomerReviews",


### PR DESCRIPTION
QA verification of VCST-5661 ("Replacing AutoMapper — Wave 3") on vcptcore-qa is complete (**PASS**, no regressions found), so the prerelease pins are reverted and the environment goes back to what it ran before.

This restores `backend/packages.json` to commit `819e951` — the state immediately before VirtoCommerce/vc-deploy-dev#6440 — so it is an exact revert, not a hand-edit.

| Module | Now (VCST-5661 prerelease) | Restored to |
|---|---|---|
| VirtoCommerce.Xapi | 3.1020.0-pr-83-32fe | 3.1019.0 (GithubReleases) |
| VirtoCommerce.XCart | 3.1031.0-pr-138-d7b6 | 3.1031.0-**pr-139**-2f78 (VCST-5801) |
| VirtoCommerce.XCatalog | 3.1019.0-pr-110-83cf | 3.1018.0 (GithubReleases) |
| VirtoCommerce.XOrder | 3.1010.0-pr-50-242d | 3.1009.0 (GithubReleases) |
| VirtoCommerce.XPickup | 3.1005.0-pr-11-32cd | 3.1004.0 (GithubReleases) |
| VirtoCommerce.CatalogCsvImportModule | 3.1005.0-pr-146-8990 | 3.1004.0 (GithubReleases) |

**XCart goes back to PR #139** — that is the VCST-5801 gift-merge pin this environment carried before, so that testing is unblocked again.

Everything else on the branch is untouched and asserted so before committing: the VCST-5450 stack (Platform 3.1063.0-pr-3098, Customer 3.1023.0-alpha, ProfileExperienceApi pr-143) and the AI / AIDocumentProcessing pins are unchanged.

Merging this triggers the "Cloud platform deployment" action — a human merges.