### PR TITLE
VCST-5566: deploy 2 artifacts to vcptcore

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1063.0-pr-3098-057b-vcst-5450-057baf32",
+  "PlatformVersion": "3.1064.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1063.0-pr-3098-057b-vcst-5450-057baf32",
+  "PlatformImageTag": "3.1064.0-pr-3105-aa2f-vcst-5566-aa2f33ea",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -50,6 +50,9 @@
         {
           "Id": "VirtoCommerce.CatalogCsvImportModule",
           "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1005.0-pr-146-8990.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.AuditLog_3.1003.0-pr-20-a47d.zip"
         }
       ]
     },

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,6 +1,6 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1064.0",
+  "PlatformVersion": "3.1064.0-pr-3105-aa2f-vcst-5566-aa2f33ea",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1064.0-pr-3105-aa2f-vcst-5566-aa2f33ea",
   "ModuleSources": [


### PR DESCRIPTION
Deploy 2 PR artifact(s) to **vcptcore** (`vcptcore-qa`) for QA verification of VCST-5566.

- `VirtoCommerce.AuditLog`: absent -> 3.1003.0-pr-20-a47d (PR VirtoCommerce/vc-module-audit-log#20)
- `platform`: 3.1063.0-pr-3098-057b-vcst-5450-057baf32 -> 3.1064.0-pr-3105-aa2f-vcst-5566-aa2f33ea (PlatformVersion + PlatformImageTag, same value) (PR VirtoCommerce/vc-platform#3105)

**Note - two side effects to review before merging:**
1. This replaces the current platform pin, which is another ticket's PR build (VCST-5450, vc-platform#3098). Merging displaces that test.
2. `VirtoCommerce.AuditLog` is not currently in this manifest, so this **adds** the module to the environment rather than bumping it.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5566

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.