### PR TITLE
VCST-5849: deploy 1 artifact to vcptcore

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -53,6 +53,9 @@
         },
         {
           "BlobName": "VirtoCommerce.AuditLog_3.1003.0-pr-20-a47d.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Catalog_3.1043.0-pr-905-7d84.zip"
         }
       ]
     },
@@ -365,10 +368,6 @@
         {
           "Id": "VirtoCommerce.PageBuilderModule",
           "Version": "3.1022.0"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "Version": "3.1042.0"
         },
         {
           "Id": "VirtoCommerce.Orders",


### PR DESCRIPTION
Deploys the **VCST-5849** fix artifact to **vcptcore-qa** for QA verification.

| Artifact | Current | Proposed |
|---|---|---|
| VirtoCommerce.Catalog | 3.1042.0 (GithubReleases) | `3.1043.0-pr-905-7d84` (AzureBlob) |

Source: VirtoCommerce/vc-module-catalog#905 — *VCST-5849: Exclude variations loading from create links* (open, all checks green).

Ticket: https://virtocommerce.atlassian.net/browse/VCST-5849

⚠️ Prerelease pin for testing — revert after verification. **Do not merge until you want the deploy to run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)