### PR TITLE
VCST-5566: exclude audit rows from LastChanges invalidation on vcptcore-qa

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -369,6 +369,8 @@
       AuditLogOptions__EntityOptions__3__NameProperty: Code
       AuditLogOptions__EntityOptions__4__TypeFullName: VirtoCommerce.CatalogModule.Core.Model.Property
       AuditLogOptions__EntityOptions__4__NameProperty: Name
+      # VCST-5566: audit rows were ~68% of Redis backplane publishes; opt-in flag from vc-module-audit-log#20
+      AuditLogOptions__ExcludeFromLastChanges: true
       VirtoCommerce__ModuleSequenceBoost__0: VirtoCommerce.AuditLog
 
       VirtoCommerce__GraphQLComplexityValidation__Enable: true


### PR DESCRIPTION
Enable the opt-in audit-log exclusion from `LastChanges` invalidation on **vcptcore-qa**, so VCST-5566 can be verified with its dominant amplification path actually switched off.

```diff
   AuditLogOptions__EntityOptions__4__NameProperty: Name
+  # VCST-5566: audit rows were ~68% of Redis backplane publishes
+  AuditLogOptions__ExcludeFromLastChanges: true
```

**Why.** `vc-module-audit-log#20` makes the exclusion **opt-in**: `Module.Initialize` only adds `AuditLogRecordEntity` / `AuditLogRecordFieldEntity` to `LastChangesOptions.IgnoredEntityTypes` when `AuditLogOptions:ExcludeFromLastChanges` is true. Both PRs are already deployed on this env (platform `3.1064.0-pr-3105-...`, audit-log `3.1003.0-pr-20-a47d`, via #6444), and a live probe of `POST /api/changes/changed-entities` shows both audit entity types still being invalidated on every write - i.e. the flag is off today, so only the per-SaveChanges dedup is active. Per the measurement in the ticket, audit-log field rows were ~68% of all backplane publishes on a cart+order load.

**Effect.** Writes to `AuditLogRecordEntity` / `AuditLogRecordFieldEntity` stop expiring `LastChangesCacheRegion` keys for those two type names. Audit logging itself is unaffected - records are still written (verified live). Anything polling `/api/changes/changed-entities` for those two type names will no longer see the date advance; that is the intended behaviour of the flag.

**Scope.** One env (`vcptcore-qa`), 2 added lines, nothing else in the file touched - asserted before committing: single-env file, anchor unique, key unique, sibling indent, byte-identical elsewhere. A push to `infra/**` triggers *Cloud infra deployment* -> `vc-build CloudEnvUpdate`.

**Rollback.** Revert this commit, or set the value to `false` - no data migration involved.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5566

**DO NOT MERGE until reviewed.**