### PR TITLE
VCST-5566: Verbose Redis backplane logging on vcptcore-qa (temporary measurement instrument)

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -81,6 +81,11 @@
       Serilog__MinimumLevel__Override__VirtoCommerce__ElasticSearch8__Data__Services__ElasticSearch8Provider: "Debug"
       Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Web__Controllers__Api__LicensingController: "Information"
       Serilog__MinimumLevel__Override__VirtoCommerce__AzureBlobAssetsModule__Core__AzureBlobProvider: "Debug"
+      # VCST-5566 (TEMPORARY): counts RedisPlatformMemoryCache LogTrace lines to prove the dedup.
+      # Dotted key form on purpose - it maps to Serilog's "Override": { "VirtoCommerce.Platform.Redis": ... } verbatim.
+      # Positive control that the instrument is armed: "Trying to cancel token with key:" lines must appear in stdout.
+      # REVERT once the measurement is taken - this is high-volume on a shared stand.
+      Serilog__MinimumLevel__Override__VirtoCommerce.Platform.Redis: "Verbose"
       #Serilog__MinimumLevel__Default: "Information"
       #Serilog__WriteTo__0: Console
       #Serilog__WriteTo__1__Name: ApplicationInsights


### PR DESCRIPTION
**TEMPORARY measurement instrument** for VCST-5566 - raises `VirtoCommerce.Platform.Redis` to `Verbose` so the backplane publishes can be counted. Please revert once the measurement is taken.

```diff
   Serilog__MinimumLevel__Override__VirtoCommerce__AzureBlobAssetsModule__Core__AzureBlobProvider: "Debug"
+  Serilog__MinimumLevel__Override__VirtoCommerce.Platform.Redis: "Verbose"
```

**What it enables.** `RedisPlatformMemoryCache` (namespace `VirtoCommerce.Platform.Redis`) logs at `LogTrace`; the ticket acceptance is a count of `Published token cancellation message` lines vs the number of distinct keys they carry. Default level is `Information` (platform `appsettings.json`), so today those lines are not emitted at all.

**Why the dotted key.** Serilog expects `MinimumLevel:Override` children to be the source-context prefix, i.e. `"Override": { "VirtoCommerce.Platform.Redis": "Verbose" }`. The dotted form maps to exactly that. The pre-existing sibling overrides in this file use the fully-nested `__` form (`...VirtoCommerce__ElasticSearch8__Data__Services__ElasticSearch8Provider`), which resolves to `Override:VirtoCommerce:ElasticSearch8:...` - a nested section rather than one prefix key. I could not verify from outside whether those actually take effect, so I did not copy the pattern. If it turns out the nested form is what works on this platform build, switch this line to `Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Redis`.

**Positive control (check this first).** `RedisPlatformMemoryCache` also logs `Trying to cancel token with key: {Key}` at Trace on every invalidation. If those lines do NOT appear in stdout after this lands, the override did not take effect and any "few publishes" reading is a false negative - do not draw conclusions from silence.

**Where the lines go.** The platform image ships only `Serilog.Sinks.Console` and `Serilog.Sinks.Debug` - no ApplicationInsights or Seq sink - so this goes to **container stdout only** (portal / Argo log stream). It is not queryable via App Insights KQL; the commented-out `Serilog__Using__1: Serilog.Sinks.ApplicationInsights` line in this file cannot work without that package in the image.

**Volume warning.** Trace on this namespace emits several lines per cache invalidation across the whole platform - on a shared QA stand that is a lot of log traffic. Short window, then revert.

Ref: https://virtocommerce.atlassian.net/browse/VCST-5566

**DO NOT MERGE until reviewed.**