### PR TITLE
VCST-5566: fix the Redis measurement instrument on vcptcore-qa (global Verbose floor; the dotted override cannot deploy)

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -81,11 +81,6 @@
       Serilog__MinimumLevel__Override__VirtoCommerce__ElasticSearch8__Data__Services__ElasticSearch8Provider: "Debug"
       Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Web__Controllers__Api__LicensingController: "Information"
       Serilog__MinimumLevel__Override__VirtoCommerce__AzureBlobAssetsModule__Core__AzureBlobProvider: "Debug"
-      # VCST-5566 (TEMPORARY): counts RedisPlatformMemoryCache LogTrace lines to prove the dedup.
-      # Dotted key form on purpose - it maps to Serilog's "Override": { "VirtoCommerce.Platform.Redis": ... } verbatim.
-      # Positive control that the instrument is armed: "Trying to cancel token with key:" lines must appear in stdout.
-      # REVERT once the measurement is taken - this is high-volume on a shared stand.
-      Serilog__MinimumLevel__Override__VirtoCommerce.Platform.Redis: "Verbose"
       #Serilog__MinimumLevel__Default: "Information"
       #Serilog__WriteTo__0: Console
       #Serilog__WriteTo__1__Name: ApplicationInsights

--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -82,6 +82,13 @@
       Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Web__Controllers__Api__LicensingController: "Information"
       Serilog__MinimumLevel__Override__VirtoCommerce__AzureBlobAssetsModule__Core__AzureBlobProvider: "Debug"
       #Serilog__MinimumLevel__Default: "Information"
+      # VCST-5566 (TEMPORARY - REVERT AFTER THE MEASUREMENT): makes RedisPlatformMemoryCache emit its
+      # LogTrace lines, so "Published token cancellation message" can be counted against the number of
+      # distinct keys they carry. A per-namespace MinimumLevel:Override cannot be used here - Serilog
+      # needs one key literally containing dots ("VirtoCommerce.Platform.Redis"), which this deployment
+      # pipeline rejects, and the nested __ form is silently dropped (child Value is null). Hence global.
+      # Positive control that it is armed: "Trying to cancel token with key:" must appear in stdout.
+      Serilog__MinimumLevel__Default: "Verbose"
       #Serilog__WriteTo__0: Console
       #Serilog__WriteTo__1__Name: ApplicationInsights
       #Serilog__WriteTo__1__Args__telemetryConverter: Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights


### PR DESCRIPTION
Fixes the instrument for VCST-5566 on `vcptcore-qa`: drops the dotted override added by #6449 (which Argo refuses to deliver) and replaces it with a form that both deploys **and** takes effect.

```diff
-  Serilog__MinimumLevel__Override__VirtoCommerce.Platform.Redis: "Verbose"
   #Serilog__MinimumLevel__Default: "Information"
+  Serilog__MinimumLevel__Default: "Verbose"
```

**Why not a per-namespace override.** Neither spelling works here:

| Key form | Deploy | Serilog |
|---|---|---|
| `Override__VirtoCommerce.Platform.Redis` | **rejected** - dots are not accepted in an env-var name | understood |
| `Override__VirtoCommerce__Platform__Redis` | accepted | **silently dropped** - child key is `VirtoCommerce`, its `Value` is `null` |

`Serilog.Settings.Configuration` reads `MinimumLevel:Override` in one non-recursive pass: it takes `overrideDirective.Key` as the prefix and `overrideDirective.Value` as the level, so a nested section yields `null` and `Enum.TryParse` fails - the rule is skipped without a warning. `MinimumLevel:Default` is read directly and needs no dots, so lowering the global floor is the only form that survives both sides.

**Cost and containment.** This is platform-wide `Verbose` on a shared QA stand - a lot of log traffic. It is deliberately temporary: take the measurement, then revert this commit. The count itself is a grep for `Published token cancellation message`, so the extra noise does not corrupt it. Logs go to **container stdout** (portal / Argo log stream) - the image ships only `Serilog.Sinks.Console` and `Serilog.Sinks.Debug`, so this is not queryable via App Insights KQL.

**Check this before trusting a low number.** `RedisPlatformMemoryCache` also logs `Trying to cancel token with key: {Key}` at the same level on every invalidation. If those lines do not appear in stdout once this lands, the floor did not take effect and any "few publishes" reading is a false negative.

**Pre-existing dead config, left untouched here.** Two overrides in this file use the same nested form and therefore have never taken effect - worth a separate decision:

- `Serilog__MinimumLevel__Override__VirtoCommerce__ElasticSearch8__Data__Services__ElasticSearch8Provider: "Debug"`
- `Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Web__Controllers__Api__LicensingController: "Information"`

Ref: https://virtocommerce.atlassian.net/browse/VCST-5566

**DO NOT MERGE until reviewed.** Revert right after the measurement.