### PR TITLE
VCST-5566: drop the temporary Verbose floor on vcptcore-qa (measurement taken)

### DIFF
--- a/infra/environments.yml
+++ b/infra/environments.yml
@@ -82,13 +82,6 @@
       Serilog__MinimumLevel__Override__VirtoCommerce__Platform__Web__Controllers__Api__LicensingController: "Information"
       Serilog__MinimumLevel__Override__VirtoCommerce__AzureBlobAssetsModule__Core__AzureBlobProvider: "Debug"
       #Serilog__MinimumLevel__Default: "Information"
-      # VCST-5566 (TEMPORARY - REVERT AFTER THE MEASUREMENT): makes RedisPlatformMemoryCache emit its
-      # LogTrace lines, so "Published token cancellation message" can be counted against the number of
-      # distinct keys they carry. A per-namespace MinimumLevel:Override cannot be used here - Serilog
-      # needs one key literally containing dots ("VirtoCommerce.Platform.Redis"), which this deployment
-      # pipeline rejects, and the nested __ form is silently dropped (child Value is null). Hence global.
-      # Positive control that it is armed: "Trying to cancel token with key:" must appear in stdout.
-      Serilog__MinimumLevel__Default: "Verbose"
       #Serilog__WriteTo__0: Console
       #Serilog__WriteTo__1__Name: ApplicationInsights
       #Serilog__WriteTo__1__Args__telemetryConverter: Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights


### PR DESCRIPTION
The VCST-5566 measurement is taken, so the temporary platform-wide `Verbose` floor added by #6455 comes back off. Merge whenever you are done with the logs - keeping it on is pure log volume on a shared stand.

```diff
-  Serilog__MinimumLevel__Default: "Verbose"
```

`AuditLogOptions__ExcludeFromLastChanges: true` from #6448 is **kept** - that one is a real setting, not an instrument (asserted before committing).

**What the instrument produced.** Both replicas analysed, both armed (pod `ctnpw`: 92 `Trying to cancel token with key` lines; pod `gpmz8`: 97). The two test saves were load-balanced onto different pods:

| Measurement | Result |
|---|---|
| Save of 7 rows across 5 distinct types (pod `ctnpw`) | **5** `LastChangesCacheRegion` publishes, **5** distinct keys - ratio **1.00** |
| Save of 42 rows across the SAME 5 types (pod `gpmz8`) | **5** publishes, **5** distinct keys - ratio **1.00** |
| Whole window per replica | `ctnpw` 17 / 11 = **1.55**; `gpmz8` 23 / 12 = **1.92** |
| Ticket baseline (single instance) | 46 273 / 36 - ratio **1285** |
| Audit entity types, both replicas | **0** publishes (#6448 working) |

Rows went 7 -> 42 and the publish count stayed flat at 5 - it tracks the number of distinct type names, not rows x inheritance depth. Absolute totals are not comparable across the two workloads (the ticket measured a 120 s 5-user cart+order load on a local stand); the dimensionless ratio and the row-independence are.

Side observation, not addressed by this fix: cluster-wide the token path is 40 publishes while the eviction / key-removal path (`Published message ... to the Redis backplane`) is 18 757 - individual cache-entry keys (settings lookups, member searches, per-id `GenericCachingRegion` entries).

Ref: https://virtocommerce.atlassian.net/browse/VCST-5566