### PR TITLE
Fix failing deploy (invalid JSON) + bump vcptcore-qa to Platform 3.1065.0 and 4 modules

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -31,9 +31,9 @@
       ],
       "Modules": [
         {
-          "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1006.0"
-        },
+          "Id": "VirtoCommerce.Loyalty",
+          "Version": "3.1006.0"
+        },
         {
           "Id": "VirtoCommerce.PageBuilderModule",
           "Version": "3.1022.0"

--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1064.0",
+  "PlatformVersion": "3.1065.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1064.0",
+  "PlatformImageTag": "3.1065.0",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -140,7 +140,7 @@
         },
         {
           "Id": "VirtoCommerce.ImageTools",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.LuceneSearch",
@@ -200,7 +200,7 @@
         },
         {
           "Id": "VirtoCommerce.Search",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
@@ -208,7 +208,7 @@
         },
         {
           "Id": "VirtoCommerce.BackgroundJobs",
-          "Version": "3.1050.0"
+          "Version": "3.1051.0"
         },
         {
           "Id": "VirtoCommerce.ProductSnapshot",
@@ -348,7 +348,7 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1020.0"
+          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.XCatalog",


### PR DESCRIPTION
Two things, both scoped to `backend/packages.json`.

## 1. Fix the broken deployment (the reason "Cloud platform deployment" has failed since 13:04)

`606ac03f` ("Sprint26-17") introduced **22 non-breaking spaces (U+00A0)** into the indentation of the `VirtoCommerce.Loyalty` entry. That makes the file **invalid JSON for a strict parser** — RFC 8259 allows only space, tab, LF and CR as whitespace.

`deploy-backend.yml` reads the platform coordinates with `jq`:

```yaml
echo "PLATFORM_IMAGE=$(cat ./backend/packages.json | jq -r '.PlatformImage')" >> $GITHUB_ENV
echo "PLATFORM_TAG=$(cat ./backend/packages.json | jq -r '.PlatformImageTag')" >> $GITHUB_ENV
```

`jq` fails, but the step still succeeds because the substitution happens inside `echo`, so both variables land **empty**. `docker build --build-arg PLATFORM_IMAGE= --build-arg PLATFORM_TAG=` then turns the Dockerfile's `FROM $PLATFORM_IMAGE:$PLATFORM_TAG` into `FROM :`:

```
ERROR: failed to build: failed to solve: failed to parse stage name ":": invalid reference format
```

`vc-build InstallModules` never catches it because the .NET JSON reader treats U+00A0 as whitespace, so the Pack step passes and the file looks fine.

| Commit | U+00A0 | Strict JSON | Deployment |
|---|---|---|---|
| 78a29569 (Sep 4) | 0 | valid | success |
| 606ac03f (13:04) | 22 | **invalid** | **failure** |
| 6f9f4c45 (13:39) | 22 | **invalid** | **failure** |
| a0e5d23a (13:51) | 22 | **invalid** | failure (hit a transient 504 in Pack first) |

This PR replaces all 22 with regular spaces, one for one — indentation is unchanged and the file now passes a strict `JSON.parse`. `backend/Dockerfile` and `theme/artifact.json` were checked and are clean.

## 2. Bump Platform + 4 modules to latest

Every bump below is already live on `vcptcore-demo` (CI-updated) and is the latest release in `modules_v3.json`.

| Component | Before | After |
|---|---|---|
| Platform (`PlatformVersion` + `PlatformImageTag`) | 3.1064.0 | 3.1065.0 |
| VirtoCommerce.Xapi | 3.1020.0 | 3.1021.0 |
| VirtoCommerce.BackgroundJobs | 3.1050.0 | 3.1051.0 |
| VirtoCommerce.ImageTools | 3.1003.0 | 3.1004.0 |
| VirtoCommerce.Search | 3.1006.0 | 3.1007.0 |

All other 83 version pins already match `vcptcore-demo` and the latest feed releases. Environment-specific pins were left untouched: the `AzureBlob` prereleases (`VirtoCommerce.AI`, `AIDocumentProcessing`, `AuditLog`) and `VirtoCommerce.Loyalty 3.1006.0` (already latest).

**Checks**
- Dependency check across all 90 pinned modules against `modules_v3.json`: 0 conflicts. The three modules requiring Platform >= 3.1065.0 (BackgroundJobs, ImageTools, Search) get it in this same change.
- `ghcr.io/virtocommerce/platform:3.1065.0` exists (manifest HEAD -> 200).
- Apart from the 6 version strings and the 22 whitespace characters, the file is byte-identical.

Merging this triggers the "Cloud platform deployment" Action and redeploys vcptcore-qa.