### PR TITLE
Update vcptcore-qa1 to latest module releases and Platform 3.1065.0

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5",
+  "PlatformVersion": "3.1065.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5",
+  "PlatformImageTag": "3.1065.0",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -19,29 +19,6 @@
         {
           "Id": "VirtoCommerce.AIDocumentProcessing",
           "BlobName": "VirtoCommerce.AIDocumentProcessing_3.901.0.zip"
-        },
-        {
-          "Id": "VirtoCommerce.Catalog",
-          "BlobName": "VirtoCommerce.Catalog_3.1042.0-pr-904-2bfa.zip"
-        },
-        {
-          "Id": "VirtoCommerce.BackupRestore",
-          "BlobName": "VirtoCommerce.BackupRestore_3.1004.0-pr-5-2048.zip"
-        },
-        {
-          "Id": "VirtoCommerce.Customer",
-          "BlobName": "VirtoCommerce.Customer_3.1023.0-alpha.1009-vcst-5450.zip"
-        },
-        {
-          "Id": "VirtoCommerce.ProfileExperienceApiModule",
-          "BlobName": "VirtoCommerce.ProfileExperienceApiModule_3.1017.0-pr-143-f9c0.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.PageBuilderModule_3.1022.0-pr-160-df89.zip"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogCsvImportModule",
-          "BlobName": "VirtoCommerce.CatalogCsvImportModule_3.1004.0-pr-145-5581.zip"
         }
       ]
     },
@@ -53,7 +30,7 @@
       "Modules": [
         {
           "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.ElasticSearch",
@@ -133,7 +110,7 @@
         },
         {
           "Id": "VirtoCommerce.OpenSearch",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.CyberSourcePayment",
@@ -141,7 +118,7 @@
         },
         {
           "Id": "VirtoCommerce.XPickup",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
         },
         {
           "Id": "VirtoCommerce.EnvironmentsCompare",
@@ -201,7 +178,7 @@
         },
         {
           "Id": "VirtoCommerce.ImageTools",
-          "Version": "3.1003.0"
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.LuceneSearch",
@@ -309,7 +286,7 @@
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1009.0"
+          "Version": "3.1011.0"
         },
         {
           "Id": "VirtoCommerce.Assets",
@@ -317,7 +294,7 @@
         },
         {
           "Id": "VirtoCommerce.Search",
-          "Version": "3.1006.0"
+          "Version": "3.1007.0"
         },
         {
           "Id": "VirtoCommerce.Store",
@@ -329,7 +306,7 @@
         },
         {
           "Id": "VirtoCommerce.XCatalog",
-          "Version": "3.1018.0"
+          "Version": "3.1019.0"
         },
         {
           "Id": "VirtoCommerce.Pricing",
@@ -341,7 +318,7 @@
         },
         {
           "Id": "VirtoCommerce.Xapi",
-          "Version": "3.1019.0"
+          "Version": "3.1021.0"
         },
         {
           "Id": "VirtoCommerce.Orders",
@@ -353,7 +330,7 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1030.0"
+          "Version": "3.1033.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
@@ -361,7 +338,7 @@
         },
         {
           "Id": "VirtoCommerce.BackgroundJobs",
-          "Version": "3.1050.0"
+          "Version": "3.1051.0"
         },
         {
           "Id": "VirtoCommerce.Notifications",
@@ -381,6 +358,30 @@
         },
         {
           "Id": "VirtoCommerce.Skyflow",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1042.0"
+        },
+        {
+          "Id": "VirtoCommerce.BackupRestore",
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.Customer",
+          "Version": "3.1023.0"
+        },
+        {
+          "Id": "VirtoCommerce.ProfileExperienceApiModule",
+          "Version": "3.1017.0"
+        },
+        {
+          "Id": "VirtoCommerce.PageBuilderModule",
+          "Version": "3.1022.0"
+        },
+        {
+          "Id": "VirtoCommerce.CatalogCsvImportModule",
           "Version": "3.1005.0"
         }
       ]


### PR DESCRIPTION
Brings `vcptcore-qa1` up to the latest published module releases and Platform, aligning it with `vcptcore-demo` (which is currently at latest across the board).

## Platform

`3.1062.0-pr-3098-a2e4-vcst-5450-a2e4afa5` → **3.1065.0** (`PlatformVersion` + `PlatformImageTag`; released 2026-09-07, same build `vcptcore-demo` runs).

## Prerelease pins moved to GithubReleases (6)

Every PR/alpha artifact pinned on this branch is **already merged and contained in the target release** — verified with the GitHub compare API (`behind_by = 0`), so nothing under test is lost:

| Module | Was (AzureBlob) | Now | Source PR | Contained in release |
|---|---|---|---|---|
| Catalog | `3.1042.0-pr-904-2bfa` | 3.1042.0 | vc-module-catalog#904 (VCST-5387) | identical |
| BackupRestore | `3.1004.0-pr-5-2048` | 3.1005.0 | vc-module-backup-restore#5 (VCST-5387) | ahead |
| Customer | `3.1023.0-alpha.1009-vcst-5450` | 3.1023.0 | vc-module-customer#314 (VCST-5450) | ahead |
| ProfileExperienceApiModule | `3.1017.0-pr-143-f9c0` | 3.1017.0 | vc-module-profile-experience-api#143 (VCST-5450) | identical |
| PageBuilderModule | `3.1022.0-pr-160-df89` | 3.1022.0 | vc-module-pagebuilder#160 (VCST-5704) | identical |
| CatalogCsvImportModule | `3.1004.0-pr-145-5581` | 3.1005.0 | vc-module-catalog-csv-import#145 (VCST-5745) | ahead |

`VirtoCommerce.AI` and `VirtoCommerce.AIDocumentProcessing` **stay on AzureBlob** — their repos publish no downloadable releases, and the only newer blobs are alpha/PR builds. The AzureBlob source is kept for them.

**Drive-by fix:** the `PageBuilderModule` AzureBlob entry had **no `Id` field** (only `BlobName`). The move gives it a proper `Id`; every module in the manifest now has one.

## Released modules bumped to latest (10)

| Module | Was | Now |
|---|---|---|
| BackgroundJobs | 3.1050.0 | 3.1051.0 |
| ImageTools | 3.1003.0 | 3.1004.0 |
| Loyalty | 3.1005.0 | 3.1006.0 |
| OpenSearch | 3.1001.0 | 3.1002.0 |
| Search | 3.1006.0 | 3.1007.0 |
| XCart | 3.1030.0 | 3.1033.0 |
| XCatalog | 3.1018.0 | 3.1019.0 |
| XOrder | 3.1009.0 | 3.1011.0 |
| XPickup | 3.1004.0 | 3.1005.0 |
| Xapi | 3.1019.0 | 3.1021.0 |

## Safety checks done before committing

- **Every one of the 16 target versions HEAD-verified** at `https://github.com/VirtoCommerce/<repo>/releases/download/<Version>/<Id>_<Version>.zip` → all **302**. This is the exact URL `vc-build InstallModules` downloads; a 404 there rolls back the whole InstallModules step. (The 2026-08-21 `Bump 45 modules to latest releases` attempt on this branch failed for exactly that reason — versions were taken from `modules_v3.json`, which can be ahead of the published releases. Here they come from the repos' release lists.)
- **Module count unchanged: 91 → 91.** No module added or removed; the only identity change is PageBuilderModule gaining its `Id`.
- Manifest re-parsed as JSON after editing; diff is +36/−35 lines, no reformatting.

## Deliberately NOT in this PR

- **`VirtoCommerce.SalesRep` 3.1007.0** — present on `vcptcore-demo`, absent here. Adding it changes the environment's module set, not its versions. Say the word and I'll add it.
- **Theme** — `theme/artifact.json` still pins the PR build `vc-theme-b2b-vue-2.56.0-pr-2426-bcda` (latest release is 2.56.0). Separate file, separate `Cloud theme deployment` workflow.

## After merge

Merging pushes to `vcptcore-qa1` and fires **Cloud platform deployment**. A green Action is **not** confirmation — verify against the live env:

```
GET https://vcptcore-qa1.govirto.com/api/platform/modules   (admin / Password1!)
```

Worth knowing: the env is **already drifting from this branch's current manifest** — the last deploy (`2a2a6bc0`, 2026-08-21, green) did not fully land. Live now reports `OpenTelemetry 3.1000.0` (manifest says 3.1001.0), `UCP 3.1004.0` (manifest 3.1005.0) and `Skyflow 3.1005.0-pr-25-82f2` (manifest 3.1005.0). This deploy should reconcile all three; check them explicitly.
