### PR TITLE
VCST-3912: pin Orders to the PR #472 build on vcptcore-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -27,6 +27,10 @@
         },
         {
           "BlobName": "VirtoCommerce.Catalog_3.1043.0-pr-906-d339.zip"
+        },
+        {
+          "Id": "VirtoCommerce.Orders",
+          "BlobName": "VirtoCommerce.Orders_3.1015.0-pr-472-dfa3.zip"
         }
       ]
     },
@@ -299,10 +303,6 @@
         {
           "Id": "VirtoCommerce.Subscription",
           "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.Orders",
-          "Version": "3.1014.0"
         },
         {
           "Id": "VirtoCommerce.Pricing",


### PR DESCRIPTION
## What

Pin `VirtoCommerce.Orders` on **vcptcore-qa** to the PR build of
[vc-module-order#472](https://github.com/VirtoCommerce/vc-module-order/pull/472) so VCST-3912 can be tested.

| | Before | After |
|---|---|---|
| Source | `GithubReleases` | `AzureBlob` (vc3prerelease) |
| Pin | `"Version": "3.1014.0"` | `"BlobName": "VirtoCommerce.Orders_3.1015.0-pr-472-dfa3.zip"` |

The `dfa3` suffix matches PR #472 head `dfa3864`. Two older artifacts exist
(`-a2d4`, `-53cf`); `-a2d4` is the commit a reviewer caught a null-principal bug on, so it must not be used.

## Why

VCST-3912 sits in **Testing**, but the change is in no release and on no environment —
every env pins Orders `3.1014.0` (latest release, 2026-08-18), PR #472 is open and 12 commits
ahead of `dev`, and a live probe of `POST /api/order/customerOrders/search` on vcptcore-qa returns
orders with no `withPrices` key. A `/qa-test` run therefore ended **BLOCKED-on-deploy** with the Test
Model and 20 Draft cases authored but nothing executed.

## Scope

One module entry moved between sources. Verified before commit: module count 90 → 90,
`PlatformVersion` untouched (3.1066.0), Orders present exactly once (not duplicated across both
sources), every other entry byte-identical, LF line endings preserved.

Precedent on this same branch: `Catalog_3.1043.0-pr-906-d339.zip`,
`PageBuilderModule_3.1024.0-pr-162-2c28.zip`, `AuditLog_3.1003.0-pr-20-a47d.zip` are already pinned this way.

## After merge

Merging pushes to `vcptcore-qa`, which auto-triggers **Cloud platform deployment**
(`on: push`, paths `backend/**`, branches `vcptcore-*`). No manual dispatch needed.

Note the platform serves the **old** container for ~1–2 min after the action goes green, so a 200 from
`/health` is not proof — confirm `GET /api/platform/modules` reports `3.1015.0-pr-472-dfa3` and that an
order payload now carries `withPrices`.

## Revert

Move the entry back to `GithubReleases` as `"Version": "3.1014.0"` and drop it from `AzureBlob`.
Do this once 3.1015.0 is released, so the env returns to a released build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)