### PR TITLE
VCST-5916: [Loyalty] Points history: "Operation" column is empty for every mission-granted points row

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -15,6 +15,9 @@
         },
         {
           "BlobName": "VirtoCommerce.Customer_3.1024.0-pr-316-1ac3.zip"
+        },
+        {
+          "BlobName": "VirtoCommerce.Loyalty_3.1007.0-pr-16-cfa5.zip"
         }
       ]
     },
@@ -24,10 +27,6 @@
         "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
       ],
       "Modules": [
-        {
-          "Id": "VirtoCommerce.Loyalty",
-          "Version": "3.1006.0"
-       },        
        {
           "Id": "VirtoCommerce.ElasticSearch",
           "Version": "3.806.0"

--- a/theme/artifact.json
+++ b/theme/artifact.json
@@ -1,3 +1,3 @@
 {
-  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.58.0-pr-2469-83d6-83d6e5d5.zip"
+  "URL": "https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.58.0-pr-2473-1e10-1e104dfa.zip"
 }


### PR DESCRIPTION
Deploy 2 PR artifact(s) to **vcst** (`vcst-qa`) for QA verification.

- `VirtoCommerce.Loyalty`: 3.1006.0 (GithubReleases) → 3.1007.0-pr-16-cfa5 (AzureBlob) (PR VirtoCommerce/vc-module-loyalty#16)
- `theme`: vc-theme-b2b-vue-2.58.0-pr-2469-83d6-83d6e5d5.zip → vc-theme-b2b-vue-2.58.0-pr-2473-1e10-1e104dfa.zip (PR VirtoCommerce/vc-frontend#2473)

Ref: https://virtocommerce.atlassian.net/browse/VCST-5916

**DO NOT MERGE until reviewed.** Revert this pin after the change is verified on the env.