### PR TITLE
Align vcptcore-qa with vcptcore-demo: platform 3.1069.0 + 7 modules

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1066.0",
+  "PlatformVersion": "3.1069.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1066.0",
+  "PlatformImageTag": "3.1069.0",
   "ModuleSources": [
     "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules_v3.json"
   ],
@@ -16,17 +16,10 @@
           "BlobName": "VirtoCommerce.AI_3.1001.0.zip"
         },
         {
-          "Id": "VirtoCommerce.PageBuilderModule",
-          "BlobName": "VirtoCommerce.PageBuilderModule_3.1024.0-pr-162-2c28.zip"
-        },
-        {
           "BlobName": "VirtoCommerce.AIDocumentProcessing_3.901.0.zip"
         },
         {
           "BlobName": "VirtoCommerce.AuditLog_3.1003.0-pr-20-a47d.zip"
-        },
-        {
-          "BlobName": "VirtoCommerce.Catalog_3.1043.0-pr-906-d339.zip"
         },
         {
           "Id": "VirtoCommerce.Orders",
@@ -66,11 +59,15 @@
         },
         {
           "Id": "VirtoCommerce.ElasticAppSearch",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.BuilderIO",
-          "Version": "3.1004.0"
+          "Version": "3.1005.0"
+        },
+        {
+          "Id": "VirtoCommerce.PageBuilderModule",
+          "Version": "3.1024.0"
         },
         {
           "Id": "VirtoCommerce.OpenIdConnectModule",
@@ -206,7 +203,11 @@
         },
         {
           "Id": "VirtoCommerce.Search",
-          "Version": "3.1007.0"
+          "Version": "3.1008.0"
+        },
+        {
+          "Id": "VirtoCommerce.Catalog",
+          "Version": "3.1044.0"
         },
         {
           "Id": "VirtoCommerce.AzureSearch",
@@ -278,7 +279,7 @@
         },
         {
           "Id": "VirtoCommerce.Notifications",
-          "Version": "3.1013.0"
+          "Version": "3.1014.0"
         },
         {
           "Id": "VirtoCommerce.Pages",
@@ -338,7 +339,7 @@
         },
         {
           "Id": "VirtoCommerce.Customer",
-          "Version": "3.1023.0"
+          "Version": "3.1024.0"
         },
         {
           "Id": "VirtoCommerce.ProfileExperienceApiModule",


### PR DESCRIPTION
Aligns the **vcptcore-qa** backend manifest with **vcptcore-demo**, except for the modules that are deliberately pinned to PR builds on qa.

## Platform
| | before | after |
|---|---|---|
| PlatformVersion / PlatformImageTag | 3.1066.0 | **3.1069.0** |

## Module version bumps (GithubReleases)
| Module | before | after |
|---|---|---|
| BuilderIO | 3.1004.0 | 3.1005.0 |
| Customer | 3.1023.0 | 3.1024.0 |
| ElasticAppSearch | 3.1001.0 | 3.1002.0 |
| Notifications | 3.1013.0 | 3.1014.0 |
| Search | 3.1007.0 | 3.1008.0 |

## Moved off prerelease blobs onto GitHub releases
| Module | before (AzureBlob) | after (GithubReleases) |
|---|---|---|
| Catalog | 3.1043.0-pr-906-d339 | 3.1044.0 |
| PageBuilderModule | 3.1024.0-pr-162-2c28 | 3.1024.0 |

## Intentionally unchanged
- **Orders** stays on its PR build `3.1015.0-pr-472-0fac` (explicitly excluded).
- qa-only modules keep their pins: `AI`, `AIDocumentProcessing`, `AuditLog` (pr-20), `Loyalty` — demo does not carry them.

## Verification
- Manifest parses as valid JSON; no duplicate module ids across sources.
- Every new version resolves in `modules_v3.json` to a real GitHub **release** asset (no alpha/prerelease URL, no private-repo 404 risk).
- Required platform version of each new module is <= 3.1069.0 (highest is Search @ 3.1065.0).
- After this change the only remaining qa-vs-demo deltas are Orders + the four qa-only modules above.

> Merging this triggers **Cloud platform deployment** for vcptcore-qa (push trigger on `backend/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)