### PR TITLE
VCST-5282: pin CatalogPersonalization PR #90 build on vcptcore-qa

### DIFF
--- a/backend/packages.json
+++ b/backend/packages.json
@@ -22,6 +22,9 @@
           "BlobName": "VirtoCommerce.AuditLog_3.1003.0-pr-20-a47d.zip"
         },
         {
+          "BlobName": "VirtoCommerce.CatalogPersonalization_3.1004.0-pr-90-9ee0.zip"
+        },
+        {
           "Id": "VirtoCommerce.Orders",
           "BlobName": "VirtoCommerce.Orders_3.1015.0-pr-472-fb82.zip"
         }
@@ -155,10 +158,6 @@
         },
         {
           "Id": "VirtoCommerce.Content",
-          "Version": "3.1003.0"
-        },
-        {
-          "Id": "VirtoCommerce.CatalogPersonalization",
           "Version": "3.1003.0"
         },
         {


### PR DESCRIPTION
## What
Repin `VirtoCommerce.CatalogPersonalization` on **vcptcore-qa** from the released `3.1003.0` (GithubReleases) to the PR #90 prerelease build `3.1004.0-pr-90-9ee0` (AzureBlob).

## Why
QA verification of [VCST-5282](https://virtocommerce.atlassian.net/browse/VCST-5282) is blocked: vcptcore-qa runs the pre-fix build, so the fix in [vc-module-catalog-personalization#90](https://github.com/VirtoCommerce/vc-module-catalog-personalization/pull/90) cannot be verified. The RED baseline has been captured on the current build; this pin provides the GREEN half.

## Scope
- 3 lines in `backend/packages.json`, one module. Nothing else touched.
- Every dependency minimum PR #90 raises is already satisfied on this environment: Platform `3.1069.0` >= `3.1039.11`, `VirtoCommerce.Catalog` `3.1044.0` >= `3.1029.4`, `VirtoCommerce.Search` `3.1008.0` >= `3.1004.1`. No platform or dependency bump needed.
- Artifact verified reachable: `VirtoCommerce.CatalogPersonalization_3.1004.0-pr-90-9ee0.zip` (270 KB, built 2026-09-10).

## Note
**Temporary pin.** PR #90 is still open and unmerged. Revert this once it is merged and released, so the environment returns to a released version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VCST-5282]: https://virtocommerce.atlassian.net/browse/VCST-5282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ